### PR TITLE
Reorganize cover preview layout and add revert option

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -1,6 +1,7 @@
 let cropper = null;
 let currentIndex = 0;
 let currentUpload = null;
+let originalImage = null;
 const genresList = ['Ação e Aventura','RPG','Horror de Sobrevivência','Puzzle','Plataforma','Shooter'];
 const modesList = ['Single-player','Co-op','PvP'];
 
@@ -69,7 +70,7 @@ function setImage(dataUrl) {
     const img = document.getElementById('image');
     img.onload = function(){
         if (cropper) cropper.destroy();
-        cropper = new Cropper(img, {aspectRatio:1, viewMode:2, crop:updatePreview});
+        cropper = new Cropper(img, {aspectRatio:1, viewMode:2, crop:updatePreview, background:false});
         if (Math.min(img.naturalWidth, img.naturalHeight) < 1080) {
             alert('Imagem menor que 1080px será ampliada.');
         }
@@ -105,8 +106,10 @@ function loadGame() {
         setMultiSelect('modes', Array.isArray(data.game.GameModes)?data.game.GameModes:[]);
         if (data.cover) {
             setImage(data.cover);
+            originalImage = data.cover;
         } else {
             clearImage();
+            originalImage = null;
         }
         currentUpload = null;
         restoreSession();
@@ -139,6 +142,15 @@ document.getElementById('imageUpload').addEventListener('change', function(){
 
 document.getElementById('save').addEventListener('click', saveGame);
 document.getElementById('skip').addEventListener('click', skipGame);
+document.getElementById('revert-image').addEventListener('click', function(){
+    if (originalImage) {
+        setImage(originalImage);
+    } else {
+        clearImage();
+    }
+    currentUpload = null;
+    saveSession();
+});
 
 ['name','summary','first-launch','developers','publishers','genres','modes'].forEach(id => {
     document.getElementById(id).addEventListener('change', saveSession);

--- a/static/style.css
+++ b/static/style.css
@@ -101,20 +101,20 @@ input:focus, textarea:focus, select:focus {
 }
 
 #preview-container {
-  margin-top: auto;
+  margin-top: 0;
   text-align: center;
 }
 
 #preview {
   max-width: 100%;
   max-height: 200px;
-  margin-top: 8px;
+  margin-top: 0;
   border-radius: 8px;
   background: var(--md-sys-color-surface);
 }
 
 .buttons {
-  margin-top: 8px;
+  margin-top: 0;
   display: flex;
   gap: 8px;
   justify-content: flex-end;
@@ -133,6 +133,24 @@ button {
 button#skip {
   background: var(--md-sys-color-secondary);
   color: #000;
+}
+
+.top-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+}
+
+
+
+#revert-image {
+  margin-bottom: 8px;
+}
+
+.cropper-bg {
+  background-color: #808080 !important;
+  background-image: none !important;
 }
 
 .right {

--- a/templates/index.html
+++ b/templates/index.html
@@ -18,6 +18,15 @@
     <div class="container">
         <div class="left">
             <form id="game-form">
+                <div class="top-row">
+                    <div id="preview-container">
+                        <img id="preview" />
+                    </div>
+                    <div class="buttons">
+                        <button type="button" id="save">Save</button>
+                        <button type="button" id="skip">Skip</button>
+                    </div>
+                </div>
                 <label>Name
                     <input type="text" id="name" />
                 </label>
@@ -39,17 +48,11 @@
                 <label>Game Modes
                     <select id="modes" multiple></select>
                 </label>
-                <div id="preview-container">
-                    <img id="preview" />
-                </div>
-                <div class="buttons">
-                    <button type="button" id="save">Save</button>
-                    <button type="button" id="skip">Skip</button>
-                </div>
             </form>
         </div>
         <div class="right">
             <input type="file" id="imageUpload" accept="image/*" />
+            <button type="button" id="revert-image">Revert Image</button>
             <div class="image-wrapper">
                 <img id="image" />
             </div>


### PR DESCRIPTION
## Summary
- Move cover preview and Save/Skip buttons above form fields to remove middle scrollbar
- Allow reverting to the original cover after uploading a new image
- Replace checkered cropper background with solid gray

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bcd08e41848333bf6738e2bbc293c7