### PR TITLE
Add back button to revisit previous game

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,6 @@
 
 Browser-based editor for reviewing games from `igdb_all_games.xlsx`. It lets you clean up metadata and produce uniform 1080×1080 cover images while saving progress to an output workbook.
 
+Use the **Back** button to return to the previously processed game if you need to correct an earlier entry.
+
 See [INSTALL.md](INSTALL.md) for installation instructions.

--- a/static/main.js
+++ b/static/main.js
@@ -130,6 +130,11 @@ function skipGame() {
       .then(r=>r.json()).then(() => { localStorage.removeItem('session'); loadGame(); });
 }
 
+function backGame() {
+    fetch('/api/back', {method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({upload_name: currentUpload})})
+      .then(r=>r.json()).then(() => { localStorage.removeItem('session'); loadGame(); });
+}
+
 document.getElementById('imageUpload').addEventListener('change', function(){
     const file = this.files[0];
     if (!file) return;
@@ -142,6 +147,7 @@ document.getElementById('imageUpload').addEventListener('change', function(){
 
 document.getElementById('save').addEventListener('click', saveGame);
 document.getElementById('skip').addEventListener('click', skipGame);
+document.getElementById('back').addEventListener('click', backGame);
 document.getElementById('revert-image').addEventListener('click', function(){
     if (originalImage) {
         setImage(originalImage);

--- a/static/style.css
+++ b/static/style.css
@@ -135,6 +135,11 @@ button#skip {
   color: #000;
 }
 
+button#back {
+  background: var(--md-sys-color-outline);
+  color: var(--md-sys-color-on-surface);
+}
+
 .top-row {
   display: flex;
   justify-content: space-between;

--- a/templates/index.html
+++ b/templates/index.html
@@ -23,6 +23,7 @@
                         <img id="preview" />
                     </div>
                     <div class="buttons">
+                        <button type="button" id="back">Back</button>
                         <button type="button" id="save">Save</button>
                         <button type="button" id="skip">Skip</button>
                     </div>


### PR DESCRIPTION
## Summary
- allow returning to previously processed game for corrections
- store edits by replacing existing entries and reloading saved data
- add Back button in UI with styling

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bcd29f48648333a811b34e2108f189