### PR TITLE
Parse genres and game modes from spreadsheet

### DIFF
--- a/app.py
+++ b/app.py
@@ -188,14 +188,16 @@ def api_game():
             'GameModes': modes,
         }
     else:
+        genres = [g.strip() for g in str(row.get('Genres', '')).split(',') if g.strip()]
+        modes = [g.strip() for g in str(row.get('Game Modes', '')).split(',') if g.strip()]
         game_fields = {
             'Name': row.get('Name', ''),
             'Summary': row.get('Summary', ''),
             'FirstLaunchDate': row.get('First Launch Date', ''),
             'Developers': row.get('Developers', ''),
             'Publishers': row.get('Publishers', ''),
-            'Genres': row.get('Genres', ''),
-            'GameModes': row.get('Game Modes', ''),
+            'Genres': genres,
+            'GameModes': modes,
         }
 
     data = {


### PR DESCRIPTION
## Summary
- Parse comma-separated genre and game mode strings from the spreadsheet so they populate the frontend selectors

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bce5cfb05c8333929767c897ab93e9