### PR TITLE
Improve summary generation error handling

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -98,11 +98,14 @@ function generateSummary() {
         if (res.summary) {
             document.getElementById('summary').value = res.summary;
             saveSession();
+        } else if (res.error) {
+            console.error(res.error);
+            alert(res.error);
         } else {
             alert('Não foi possível gerar o resumo.');
         }
     })
-    .catch(() => alert('Erro ao gerar resumo.'))
+    .catch(err => { console.error(err); alert('Erro ao gerar resumo.'); })
     .finally(() => {
         btn.disabled = false;
         btn.textContent = 'Gerar Resumo';


### PR DESCRIPTION
## Summary
- Raise explicit errors when OpenAI API key or game name is missing
- Surface summary generation failures via `/api/summary` endpoint
- Log and display errors in the browser when summary generation fails

## Testing
- `python -m py_compile app.py`
- `node --check static/main.js`


------
https://chatgpt.com/codex/tasks/task_e_68bcf339352483338408db9000db5b3a