### PR TITLE
Add reset option, longer summaries, and genre parsing

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -188,6 +188,27 @@ function backGame() {
       .then(r=>r.json()).then(() => { localStorage.removeItem('session'); loadGame(); });
 }
 
+function resetFields() {
+    fetch(`/api/game/${currentIndex}/raw`).then(r=>r.json()).then(data=>{
+        document.getElementById('name').value = data.game.Name || '';
+        document.getElementById('summary').value = data.game.Summary || '';
+        document.getElementById('first-launch').value = data.game.FirstLaunchDate || '';
+        document.getElementById('developers').value = data.game.Developers || '';
+        document.getElementById('publishers').value = data.game.Publishers || '';
+        setChoices(genresChoices, Array.isArray(data.game.Genres)?data.game.Genres:[]);
+        setChoices(modesChoices, Array.isArray(data.game.GameModes)?data.game.GameModes:[]);
+        if (data.cover) {
+            setImage(data.cover);
+            originalImage = data.cover;
+        } else {
+            clearImage();
+            originalImage = null;
+        }
+        currentUpload = null;
+        saveSession();
+    });
+}
+
 document.getElementById('imageUpload').addEventListener('change', function(){
     const file = this.files[0];
     if (!file) return;
@@ -208,14 +229,19 @@ genBtn.addEventListener('click', generateSummary);
 document.getElementById('save').addEventListener('click', saveGame);
 document.getElementById('skip').addEventListener('click', skipGame);
 document.getElementById('back').addEventListener('click', backGame);
+document.getElementById('reset').addEventListener('click', resetFields);
 document.getElementById('revert-image').addEventListener('click', function(){
-    if (originalImage) {
-        setImage(originalImage);
-    } else {
-        clearImage();
-    }
-    currentUpload = null;
-    saveSession();
+    fetch(`/api/game/${currentIndex}/raw`).then(r=>r.json()).then(data=>{
+        if (data.cover) {
+            setImage(data.cover);
+            originalImage = data.cover;
+        } else {
+            clearImage();
+            originalImage = null;
+        }
+        currentUpload = null;
+        saveSession();
+    });
 });
 
 ['name','summary','first-launch','developers','publishers'].forEach(id => {

--- a/templates/index.html
+++ b/templates/index.html
@@ -28,6 +28,7 @@
                         <button type="button" id="back">Back</button>
                         <button type="button" id="save">Save</button>
                         <button type="button" id="skip">Skip</button>
+                        <button type="button" id="reset">Reset</button>
                     </div>
                 </div>
                 <label>Name


### PR DESCRIPTION
## Summary
- Extend AI-generated game summaries to produce 3–5 sentence descriptions.
- Parse genre data more reliably and expose a raw-data endpoint for resets.
- Add Reset control and improved Revert Image functionality that reloads original cover art.

## Testing
- `python -m py_compile app.py`
- `node --check static/main.js`


------
https://chatgpt.com/codex/tasks/task_e_68bd00dfa1b48333b9c5d8164749abb9