### PR TITLE
Show image resolution and allow upload after reset

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -3,6 +3,7 @@ let currentIndex = 0;
 let currentUpload = null;
 let originalImage = null;
 let genresChoices, modesChoices;
+const imageUploadInput = document.getElementById('imageUpload');
 const genresList = [
     'Ação e Aventura',
     'Cartas e Tabuleiro',
@@ -127,16 +128,20 @@ function setImage(dataUrl) {
         if (Math.min(img.naturalWidth, img.naturalHeight) < 1080) {
             alert('Imagem menor que 1080px será ampliada.');
         }
+        document.getElementById('image-resolution').textContent = `${img.naturalWidth}x${img.naturalHeight}`;
         updatePreview();
     };
     img.src = dataUrl;
+    imageUploadInput.value = '';
 }
 
 function clearImage() {
     if (cropper) { cropper.destroy(); cropper = null; }
     document.getElementById('image').src = '';
     document.getElementById('preview').src = '';
+    document.getElementById('image-resolution').textContent = '';
     currentUpload = null;
+    imageUploadInput.value = '';
     saveSession();
 }
 
@@ -209,7 +214,7 @@ function resetFields() {
     });
 }
 
-document.getElementById('imageUpload').addEventListener('change', function(){
+imageUploadInput.addEventListener('change', function(){
     const file = this.files[0];
     if (!file) return;
     const formData = new FormData();

--- a/static/style.css
+++ b/static/style.css
@@ -193,11 +193,23 @@ button#back {
   justify-content: center;
   align-items: center;
   overflow: hidden;
+  position: relative;
 }
 
 .image-wrapper img {
   max-width: 100%;
   max-height: 100%;
+}
+
+.resolution-label {
+  position: absolute;
+  bottom: 8px;
+  left: 8px;
+  background: rgba(0,0,0,0.6);
+  color: #fff;
+  padding: 2px 6px;
+  font-size: 0.8rem;
+  border-radius: 4px;
 }
 
 @media (max-width: 768px) {

--- a/templates/index.html
+++ b/templates/index.html
@@ -61,6 +61,7 @@
             <button type="button" id="revert-image">Revert Image</button>
             <div class="image-wrapper">
                 <img id="image" />
+                <div id="image-resolution" class="resolution-label"></div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- Display original image dimensions in the cropper area
- Resetting an image clears upload input so the same file can be reselected

## Testing
- `python -m py_compile app.py`
- `node --check static/main.js`


------
https://chatgpt.com/codex/tasks/task_e_68bd8f21b0748333ba918263869178c3