### PR TITLE
Improve button clarity and replace alert popups

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -84,6 +84,16 @@ function restoreSession() {
     currentUpload = data.upload_name;
 }
 
+function showAlert(message, type = 'success') {
+    const banner = document.getElementById('alert-banner');
+    banner.textContent = message;
+    banner.className = type;
+    banner.style.display = 'block';
+    setTimeout(() => {
+        banner.style.display = 'none';
+    }, 5000);
+}
+
 function generateSummary() {
     const name = document.getElementById('name').value;
     const btn = document.getElementById('generate-summary');
@@ -133,7 +143,7 @@ function setImage(dataUrl) {
             background: false
         });
         if (Math.min(img.naturalWidth, img.naturalHeight) < 1080) {
-            alert('Imagem menor que 1080px será ampliada.');
+            showAlert('Imagem menor que 1080px será ampliada.', 'warning');
         }
         document.getElementById('image-resolution').textContent = `${img.naturalWidth}x${img.naturalHeight}`;
         updatePreview();
@@ -183,12 +193,20 @@ function loadGame() {
 }
 
 function saveGame() {
-    if (!cropper) { alert('Selecione uma imagem'); return; }
+    if (!cropper) { showAlert('Selecione uma imagem', 'warning'); return; }
     const canvas = cropper.getCroppedCanvas({width:1080, height:1080});
     const dataUrl = canvas.toDataURL('image/jpeg', 0.9);
     const fields = collectFields();
-    fetch('/api/save', {method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({index: currentIndex, fields: fields, image: dataUrl, upload_name: currentUpload})})
-      .then(r=>r.json()).then(() => { localStorage.removeItem('session'); currentUpload = null; });
+    fetch('/api/save', {
+        method:'POST',
+        headers:{'Content-Type':'application/json'},
+        body:JSON.stringify({index: currentIndex, fields: fields, image: dataUrl, upload_name: currentUpload})
+    })
+      .then(r=>r.json()).then(() => {
+          localStorage.removeItem('session');
+          currentUpload = null;
+          showAlert('The game was saved.', 'success');
+      });
 }
 
 function skipGame() {

--- a/static/style.css
+++ b/static/style.css
@@ -6,6 +6,8 @@
   --md-sys-color-secondary: #CFD11A;
   --md-sys-color-outline: #222222;
   --md-sys-color-primary-contrast: #D4D2D5;
+  --md-sys-color-info: #1E88E5;
+  --md-sys-color-success: #388E3C;
 }
 
 html, body {
@@ -149,6 +151,18 @@ button#previous {
   color: var(--md-sys-color-on-surface);
 }
 
+button#next {
+  background: var(--md-sys-color-info);
+}
+
+button#save {
+  background: var(--md-sys-color-success);
+}
+
+button#reset {
+  background: var(--md-sys-color-primary);
+}
+
 .top-row {
   display: flex;
   justify-content: space-between;
@@ -268,5 +282,27 @@ button#previous {
   background: var(--md-sys-color-primary);
   border: 1px solid var(--md-sys-color-primary);
   color: var(--md-sys-color-primary-contrast);
+}
+
+#alert-banner {
+  position: fixed;
+  top: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 12px 24px;
+  border-radius: 4px;
+  display: none;
+  z-index: 1000;
+  font-weight: 500;
+}
+
+#alert-banner.success {
+  background: var(--md-sys-color-success);
+  color: #fff;
+}
+
+#alert-banner.warning {
+  background: var(--md-sys-color-secondary);
+  color: #000;
 }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -12,6 +12,7 @@
     <script src="https://cdn.jsdelivr.net/npm/choices.js/public/assets/scripts/choices.min.js"></script>
 </head>
 <body>
+    <div id="alert-banner"></div>
     <header>
         <h2 id="game-name"></h2>
         <div id="caption"></div>


### PR DESCRIPTION
## Summary
- Color-code navigation and action buttons for clarity
- Add alert banner for save confirmations and small image warnings

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68be6964f078833393d863a9340fe6fb