### PR TITLE
fix: expose cropper element import

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,7 @@
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
     "framer-motion": "^10.12.16",
-    "cropperjs": "^2.0.0"
+    "cropperjs": "^2.0.1"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.0.0",


### PR DESCRIPTION
## Summary
- bump cropperjs to 2.0.1 to expose `element` subpath so build succeeds

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be8121f20c8333ac13a4d7bd85117c