### PR TITLE
Remove cropperjs dependency and simplify image preview

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,8 +15,7 @@
     "@chakra-ui/react": "^2.7.2",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
-    "framer-motion": "^10.12.16",
-    "cropperjs": "^2.0.1"
+    "framer-motion": "^10.12.16"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.0.0",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 import {
   Box,
   Flex,
@@ -14,8 +14,6 @@ import {
   Stack,
   SimpleGrid
 } from '@chakra-ui/react'
-import 'cropperjs/element'
-import 'cropperjs/dist/cropper.css'
 
 const genresList = [
   'Ação e Aventura',
@@ -63,7 +61,6 @@ export default function App() {
   const [uploadName, setUploadName] = useState(null)
   const [done, setDone] = useState(false)
   const [message, setMessage] = useState('')
-  const cropperRef = useRef(null)
 
   useEffect(() => {
     loadGame()
@@ -189,18 +186,10 @@ export default function App() {
   }
 
   function saveGame() {
-    let dataUrl = image
-    const cropperEl = cropperRef.current
-    if (cropperEl && cropperEl.cropper) {
-      const canvas = cropperEl.cropper.getCroppedCanvas()
-      if (canvas) {
-        dataUrl = canvas.toDataURL()
-      }
-    }
     const payload = {
       index,
       fields,
-      image: dataUrl,
+      image,
       upload_name: uploadName
     }
     fetch('/api/save', {
@@ -337,11 +326,11 @@ export default function App() {
             <Input type="file" onChange={handleUpload} accept="image/*" />
           </FormControl>
           {image && (
-            <cropper-cropper
-              ref={cropperRef}
+            <Box
+              as="img"
               src={image}
-              style={{ width: '100%', height: '100%' }}
-            ></cropper-cropper>
+              style={{ width: '100%', height: '100%', objectFit: 'contain' }}
+            />
           )}
           <Stack direction="row" spacing={2} mt={3}>
             <Button onClick={previousGame}>Previous</Button>


### PR DESCRIPTION
## Summary
- drop unused cropperjs dependency
- show uploaded images with a basic preview instead of cropper element
- simplify save logic to send the original image

## Testing
- `npm test` *(fails: No test files found, exiting with code 1)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be8a6124e883338c28838bfb6bb144