### PR TITLE
Handle missing cover images with placeholder fallback

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -4,6 +4,7 @@ let currentUpload = null;
 let originalImage = null;
 let genresChoices, modesChoices;
 const imageUploadInput = document.getElementById('imageUpload');
+const placeholderImage = 'https://i.imgur.com/XZvvGuQ.png';
 const genresList = [
     'Ação e Aventura',
     'Cartas e Tabuleiro',
@@ -59,10 +60,11 @@ function collectFields() {
 }
 
 function saveSession() {
+    const imgSrc = document.getElementById('image').src;
     const data = {
         index: currentIndex,
         fields: collectFields(),
-        image: document.getElementById('image').src,
+        image: imgSrc && imgSrc !== placeholderImage ? imgSrc : '',
         upload_name: currentUpload
     };
     localStorage.setItem('session', JSON.stringify(data));
@@ -185,6 +187,7 @@ function loadGame() {
             originalImage = data.cover;
         } else {
             clearImage();
+            document.getElementById('image').src = placeholderImage;
             originalImage = null;
         }
         currentUpload = null;
@@ -256,6 +259,7 @@ function resetFields() {
             originalImage = data.cover;
         } else {
             clearImage();
+            document.getElementById('image').src = placeholderImage;
             originalImage = null;
         }
         currentUpload = null;
@@ -299,6 +303,7 @@ document.getElementById('revert-image').addEventListener('click', function(){
             originalImage = data.cover;
         } else {
             clearImage();
+            document.getElementById('image').src = placeholderImage;
             originalImage = null;
         }
         currentUpload = null;


### PR DESCRIPTION
## Summary
- Fetch cover images remotely when no local file is found and warn if unavailable
- Return `null` cover data when no image exists and avoid storing placeholder URLs in session
- Show a default placeholder graphic on the client whenever cover data is missing

## Testing
- `python -m py_compile app.py`
- `node --check static/main.js`


------
https://chatgpt.com/codex/tasks/task_e_68bebbbda9a483339e8f042091fcbd4d