### PR TITLE
Handle empty cells and warn user

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -202,6 +202,9 @@ function loadGame() {
             }
             currentUpload = null;
             restoreSession();
+            if (Array.isArray(data.missing) && data.missing.length) {
+                showAlert('Campos vazios: ' + data.missing.join(', '), 'warning');
+            }
         })
         .catch(err => {
             console.error(err.stack || err);


### PR DESCRIPTION
## Summary
- avoid NaN values from Excel by adding a helper that converts missing cells to empty strings and tracks which fields are missing
- expose missing field names from `/api/game` so the frontend can alert the user
- update frontend to display a warning when any required field is blank

## Testing
- `python -m py_compile app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68becf97e81c83339db3096b0d19401a