### PR TITLE
Protect application with simple password login

### DIFF
--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Login</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+    <form method="post">
+        {% if error %}<p>{{ error }}</p>{% endif %}
+        <label>Password
+            <input type="password" name="password" />
+        </label>
+        <button type="submit">Login</button>
+    </form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add session-based password check using APP_PASSWORD and secret key
- gate all routes behind login and add logout endpoint
- create login template

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bed29c944c83339a572fab38f31163