### PR TITLE
Reposition preview and streamline editor layout

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -142,6 +142,20 @@ body {
   color: #0f172a;
 }
 
+.material-symbols-rounded {
+  font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
+}
+
+.btn-icon {
+  font-size: 1.35rem;
+  line-height: 1;
+}
+
+.btn-label {
+  display: inline-flex;
+  align-items: center;
+}
+
 .btn:disabled {
   opacity: 0.6;
   cursor: not-allowed;
@@ -205,6 +219,13 @@ body {
 .details-column {
   overflow-y: auto;
   padding-right: 8px;
+}
+
+.details-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(240px, 1fr);
+  gap: 24px;
+  align-items: start;
 }
 
 #game-form {
@@ -281,31 +302,6 @@ textarea {
   gap: 12px;
 }
 
-.static-field {
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: 10px;
-  padding: 12px 16px;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  gap: 6px;
-  min-height: 68px;
-}
-
-.static-label {
-  font-size: 0.8rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--color-muted);
-}
-
-.static-value {
-  font-size: 1.1rem;
-  font-weight: 600;
-  color: var(--color-text);
-}
-
 .chip-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
@@ -318,45 +314,30 @@ textarea {
   gap: 8px;
 }
 
-.field-accordion {
+.field-card {
   border-radius: 12px;
   border: 1px solid var(--color-border);
   background: var(--color-surface);
-  overflow: hidden;
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.02);
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
 }
 
-.field-accordion summary {
-  list-style: none;
-  cursor: pointer;
-  padding: 14px 18px;
+.field-card-title {
+  margin: 0;
   font-weight: 600;
   color: var(--color-text);
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
-
-.field-accordion summary::-webkit-details-marker {
-  display: none;
-}
-
-.field-accordion summary::after {
-  content: '⌄';
-  transform: rotate(-90deg);
-  transition: transform 160ms ease;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
   font-size: 0.9rem;
-  color: var(--color-muted);
-}
-
-.field-accordion[open] summary::after {
-  transform: rotate(0deg);
 }
 
 .field-accordion-content {
   display: grid;
   gap: 18px 24px;
-  padding: 0 18px 18px;
+  padding: 0;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
@@ -425,8 +406,8 @@ textarea {
 }
 
 .image-panel {
-  display: grid;
-  grid-template-rows: minmax(380px, 1fr) auto;
+  display: flex;
+  flex-direction: column;
   gap: 20px;
 }
 
@@ -469,6 +450,7 @@ textarea {
   gap: 14px;
   align-items: center;
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.02);
+  width: 100%;
 }
 
 .preview-panel h3 {
@@ -481,8 +463,9 @@ textarea {
 }
 
 #preview {
-  width: 200px;
-  height: 200px;
+  width: 100%;
+  max-width: 280px;
+  aspect-ratio: 1 / 1;
   object-fit: cover;
   border-radius: 16px;
   border: 1px solid rgba(255, 255, 255, 0.08);
@@ -558,6 +541,15 @@ textarea {
   .image-column {
     padding-left: 0;
   }
+
+  .details-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .preview-panel {
+    max-width: 360px;
+    margin: 0 auto;
+  }
 }
 
 @media (max-width: 720px) {
@@ -575,7 +567,16 @@ textarea {
   }
 
   .action-row {
-    grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+  }
+
+  .action-row .btn {
+    gap: 0;
+    padding: 10px;
+  }
+
+  .action-row .btn .btn-label {
+    display: none;
   }
 
   .editor-body {

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,6 +6,7 @@
     <title>Game Editor</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/cropperjs@1.5.13/dist/cropper.min.css" />
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@24,400,0,0" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/choices.js/public/assets/styles/choices.min.css" />
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}" />
     <script src="https://cdn.jsdelivr.net/npm/cropperjs@1.5.13/dist/cropper.min.js"></script>
@@ -31,67 +32,84 @@
             </div>
         </div>
         <nav class="action-row" id="action-bar" aria-label="Game actions">
-            <button type="button" id="previous" class="btn btn-blue">Previous</button>
-            <button type="button" id="next" class="btn btn-blue">Next</button>
-            <button type="button" id="save" class="btn btn-green">Save</button>
-            <button type="button" id="skip" class="btn btn-yellow">Skip</button>
-            <button type="button" id="reset" class="btn btn-red">Reset</button>
+            <button type="button" id="previous" class="btn btn-blue" aria-label="Previous">
+                <span class="material-symbols-rounded btn-icon" aria-hidden="true">chevron_left</span>
+                <span class="btn-label">Previous</span>
+            </button>
+            <button type="button" id="next" class="btn btn-blue" aria-label="Next">
+                <span class="material-symbols-rounded btn-icon" aria-hidden="true">chevron_right</span>
+                <span class="btn-label">Next</span>
+            </button>
+            <button type="button" id="save" class="btn btn-green" aria-label="Save" data-default-label="Save">
+                <span class="material-symbols-rounded btn-icon" aria-hidden="true">save</span>
+                <span class="btn-label">Save</span>
+            </button>
+            <button type="button" id="skip" class="btn btn-yellow" aria-label="Skip">
+                <span class="material-symbols-rounded btn-icon" aria-hidden="true">skip_next</span>
+                <span class="btn-label">Skip</span>
+            </button>
+            <button type="button" id="reset" class="btn btn-red" aria-label="Reset">
+                <span class="material-symbols-rounded btn-icon" aria-hidden="true">refresh</span>
+                <span class="btn-label">Reset</span>
+            </button>
         </nav>
     </header>
     <main class="editor-body">
         <section class="details-column">
-            <form id="game-form">
-                <div class="field-grid">
-                    <label>Title
-                        <input type="text" id="name" autocomplete="off" />
-                    </label>
-                    <div class="static-field">
-                        <span class="static-label">Game ID</span>
-                        <span id="game-id-display" class="static-value">—</span>
+            <div class="details-layout">
+                <form id="game-form">
+                    <div class="field-grid">
+                        <label>Title
+                            <input type="text" id="name" autocomplete="off" />
+                        </label>
+                        <label>First Launch Date
+                            <input type="text" id="first-launch" autocomplete="off" />
+                        </label>
                     </div>
-                    <label>First Launch Date
-                        <input type="text" id="first-launch" autocomplete="off" />
-                    </label>
-                </div>
-                <div class="summary-section">
-                    <div class="summary-header">
-                        <label for="summary">Summary</label>
-                        <div class="summary-actions">
-                            <button type="button" id="expand-summary" class="btn btn-outline">Expand</button>
-                            <button type="button" id="generate-summary" class="btn btn-outline">Gerar Resumo</button>
+                    <div class="summary-section">
+                        <div class="summary-header">
+                            <label for="summary">Summary</label>
+                            <div class="summary-actions">
+                                <button type="button" id="expand-summary" class="btn btn-outline">Expand</button>
+                                <button type="button" id="generate-summary" class="btn btn-outline">Gerar Resumo</button>
+                            </div>
+                        </div>
+                        <textarea id="summary"></textarea>
+                    </div>
+                    <div class="chip-field">
+                        <label for="platforms">Platforms</label>
+                        <select id="platforms" multiple></select>
+                    </div>
+                    <div class="chip-grid">
+                        <div class="chip-field">
+                            <label for="genres">Genres</label>
+                            <select id="genres" multiple aria-label="Genres"></select>
+                        </div>
+                        <div class="chip-field">
+                            <label for="modes">Game Modes</label>
+                            <select id="modes" multiple aria-label="Game modes"></select>
                         </div>
                     </div>
-                    <textarea id="summary"></textarea>
-                </div>
-                <div class="chip-field">
-                    <label for="platforms">Platforms</label>
-                    <select id="platforms" multiple></select>
-                </div>
-                <div class="chip-grid">
-                    <div class="chip-field">
-                        <label for="genres">Genres</label>
-                        <select id="genres" multiple aria-label="Genres"></select>
-                    </div>
-                    <div class="chip-field">
-                        <label for="modes">Game Modes</label>
-                        <select id="modes" multiple aria-label="Game modes"></select>
-                    </div>
-                </div>
-                <details class="field-accordion" id="meta-accordion">
-                    <summary>Additional metadata</summary>
-                    <div class="field-accordion-content">
-                        <label>Category
-                            <select id="category"></select>
-                        </label>
-                        <label>Developers
-                            <input type="text" id="developers" autocomplete="off" />
-                        </label>
-                        <label>Publishers
-                            <input type="text" id="publishers" autocomplete="off" />
-                        </label>
-                    </div>
-                </details>
-            </form>
+                    <section class="field-card" id="meta-panel">
+                        <h2 class="field-card-title">Additional metadata</h2>
+                        <div class="field-accordion-content">
+                            <label>Category
+                                <select id="category"></select>
+                            </label>
+                            <label>Developers
+                                <input type="text" id="developers" autocomplete="off" />
+                            </label>
+                            <label>Publishers
+                                <input type="text" id="publishers" autocomplete="off" />
+                            </label>
+                        </div>
+                    </section>
+                </form>
+                <aside class="preview-panel" aria-label="Cropped preview">
+                    <h3>Preview</h3>
+                    <img id="preview" alt="Cropped preview" />
+                </aside>
+            </div>
         </section>
         <aside class="image-column">
             <input type="file" id="imageUpload" accept="image/*" />
@@ -103,10 +121,6 @@
                 <div class="image-wrapper">
                     <img id="image" alt="Cover image workspace" />
                     <div id="image-resolution" class="resolution-label"></div>
-                </div>
-                <div class="preview-panel">
-                    <h3>Preview</h3>
-                    <img id="preview" alt="Cropped preview" />
                 </div>
             </div>
         </aside>


### PR DESCRIPTION
## Summary
- relocate the cover preview into the form column and remove the extra Game ID display and accordion control
- refresh styling to support the new preview placement and show icon-only navigation buttons on small screens
- update front-end logic to handle the revised save button markup and relocated preview

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c89cf5deac83339ddef699ea7add97