### PR TITLE
Rework header layout and mobile navigation

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -57,10 +57,6 @@ function setChoices(instance, values) {
 function updateGameIdDisplay(idValue) {
     const idText = idValue ? String(idValue) : '—';
     document.getElementById('game-id').textContent = idText;
-    const metaDisplay = document.getElementById('game-id-display');
-    if (metaDisplay) {
-        metaDisplay.textContent = idText;
-    }
 }
 
 function collectFields() {
@@ -116,8 +112,6 @@ function restoreSession() {
     document.getElementById('game-name').textContent = data.fields.Name || 'Untitled Game';
     const summaryEl = document.getElementById('summary');
     summaryEl.value = data.fields.Summary;
-    summaryEl.classList.remove('expanded');
-    document.getElementById('expand-summary').textContent = 'Expand';
     document.getElementById('first-launch').value = data.fields.FirstLaunchDate;
     document.getElementById('developers').value = data.fields.Developers;
     document.getElementById('publishers').value = data.fields.Publishers;
@@ -260,8 +254,6 @@ function applyGameData(data) {
     document.getElementById('name').value = data.game.Name || '';
     const summaryEl = document.getElementById('summary');
     summaryEl.value = data.game.Summary || '';
-    summaryEl.classList.remove('expanded');
-    document.getElementById('expand-summary').textContent = 'Expand';
     document.getElementById('first-launch').value = data.game.FirstLaunchDate || '';
     document.getElementById('developers').value = data.game.Developers || '';
     document.getElementById('publishers').value = data.game.Publishers || '';
@@ -415,8 +407,6 @@ function resetFields() {
         document.getElementById('game-name').textContent = data.game.Name || 'Untitled Game';
         const summaryEl = document.getElementById('summary');
         summaryEl.value = data.game.Summary || '';
-        summaryEl.classList.remove('expanded');
-        document.getElementById('expand-summary').textContent = 'Expand';
         document.getElementById('first-launch').value = data.game.FirstLaunchDate || '';
         document.getElementById('developers').value = data.game.Developers || '';
         document.getElementById('publishers').value = data.game.Publishers || '';
@@ -489,17 +479,6 @@ document.getElementById('revert-image').addEventListener('click', revertImage);
 document.getElementById('name').addEventListener('input', (event) => {
     const value = event.target.value;
     document.getElementById('game-name').textContent = value || 'Untitled Game';
-});
-
-document.getElementById('expand-summary').addEventListener('click', () => {
-    const summary = document.getElementById('summary');
-    if (summary.classList.contains('expanded')) {
-        summary.classList.remove('expanded');
-        document.getElementById('expand-summary').textContent = 'Expand';
-    } else {
-        summary.classList.add('expanded');
-        document.getElementById('expand-summary').textContent = 'Collapse';
-    }
 });
 
 document.addEventListener('keydown', (event) => {

--- a/static/style.css
+++ b/static/style.css
@@ -19,11 +19,13 @@
 
 html,
 body {
-  min-height: 100%;
+  height: 100%;
 }
 
 body {
   margin: 0;
+  min-height: 100vh;
+  overflow: hidden;
   background: var(--color-background);
   color: var(--color-text);
   font-family: 'Roboto', sans-serif;
@@ -40,16 +42,27 @@ body {
   backdrop-filter: blur(8px);
   padding: 20px 32px 24px;
   box-shadow: 0 10px 30px rgba(4, 6, 15, 0.55);
-  display: flex;
-  flex-direction: column;
-  gap: 20px;
 }
 
 .header-main {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  gap: 24px;
+  gap: 32px;
+}
+
+.header-left {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  min-width: 0;
+}
+
+.header-right {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  align-items: flex-end;
 }
 
 .header-info h1 {
@@ -80,11 +93,12 @@ body {
 }
 
 .progress-indicator {
-  min-width: 260px;
+  min-width: 220px;
   display: flex;
   flex-direction: column;
   gap: 8px;
   align-items: flex-end;
+  flex-shrink: 0;
 }
 
 .progress-metrics {
@@ -119,8 +133,8 @@ body {
 }
 
 .action-row {
-  display: grid;
-  grid-template-columns: repeat(5, minmax(0, 1fr));
+  display: flex;
+  flex-wrap: wrap;
   gap: 16px;
 }
 
@@ -140,6 +154,7 @@ body {
   transition: transform 120ms ease, box-shadow 120ms ease, opacity 120ms ease;
   min-height: 44px;
   color: #0f172a;
+  position: relative;
 }
 
 .btn:disabled {
@@ -185,6 +200,23 @@ body {
   transform: translateY(-1px);
 }
 
+.btn-icon {
+  width: 20px;
+  height: 20px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.btn-icon svg {
+  width: 100%;
+  height: 100%;
+}
+
+.btn-label {
+  white-space: nowrap;
+}
+
 .editor-body {
   flex: 1;
   display: grid;
@@ -192,6 +224,7 @@ body {
   gap: 32px;
   padding: 28px 32px 40px;
   overflow: hidden;
+  min-height: 0;
 }
 
 .details-column,
@@ -200,6 +233,7 @@ body {
   overflow: hidden;
   display: flex;
   flex-direction: column;
+  min-height: 0;
 }
 
 .details-column {
@@ -254,15 +288,6 @@ textarea {
   resize: vertical;
 }
 
-#summary {
-  transition: max-height 200ms ease;
-  max-height: 280px;
-}
-
-#summary.expanded {
-  max-height: none;
-}
-
 .summary-section {
   display: flex;
   flex-direction: column;
@@ -274,36 +299,6 @@ textarea {
   align-items: center;
   justify-content: space-between;
   gap: 16px;
-}
-
-.summary-actions {
-  display: flex;
-  gap: 12px;
-}
-
-.static-field {
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: 10px;
-  padding: 12px 16px;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  gap: 6px;
-  min-height: 68px;
-}
-
-.static-label {
-  font-size: 0.8rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--color-muted);
-}
-
-.static-value {
-  font-size: 1.1rem;
-  font-weight: 600;
-  color: var(--color-text);
 }
 
 .chip-grid {
@@ -425,8 +420,10 @@ textarea {
 }
 
 .image-panel {
-  display: grid;
-  grid-template-rows: minmax(380px, 1fr) auto;
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
   gap: 20px;
 }
 
@@ -440,6 +437,8 @@ textarea {
   align-items: center;
   overflow: hidden;
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.02);
+  flex: 1;
+  min-height: 0;
 }
 
 .image-wrapper img {
@@ -459,33 +458,24 @@ textarea {
   letter-spacing: 0.04em;
 }
 
-.preview-panel {
-  background: var(--color-surface);
+.header-preview {
+  width: 140px;
+  height: 140px;
   border-radius: 16px;
   border: 1px solid var(--color-border);
-  padding: 18px;
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
-  align-items: center;
+  background: var(--color-surface);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.02);
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
 }
 
-.preview-panel h3 {
-  margin: 0;
-  font-weight: 500;
-  color: var(--color-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  font-size: 0.85rem;
-}
-
-#preview {
-  width: 200px;
-  height: 200px;
+.header-preview img {
+  width: 100%;
+  height: 100%;
   object-fit: cover;
-  border-radius: 16px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
   background: rgba(15, 23, 42, 0.3);
 }
 
@@ -568,14 +558,51 @@ textarea {
   .header-main {
     flex-direction: column;
     align-items: stretch;
+    gap: 20px;
+  }
+
+  .header-right {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .header-preview {
+    width: 104px;
+    height: 104px;
   }
 
   .progress-indicator {
+    min-width: unset;
     align-items: flex-start;
   }
 
   .action-row {
-    grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+    flex-wrap: nowrap;
+    justify-content: space-between;
+    gap: 12px;
+  }
+
+  .btn {
+    padding: 10px;
+    min-width: 0;
+  }
+
+  .btn-icon {
+    width: 24px;
+    height: 24px;
+  }
+
+  .btn-label {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
   }
 
   .editor-body {
@@ -585,10 +612,6 @@ textarea {
   .summary-header {
     flex-direction: column;
     align-items: flex-start;
-  }
-
-  .summary-actions {
-    width: 100%;
-    justify-content: flex-start;
+    gap: 12px;
   }
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -15,28 +15,75 @@
     <div id="toast" role="status" aria-live="polite"></div>
     <header class="editor-header">
         <div class="header-main">
-            <div class="header-info">
-                <h1 id="game-name"></h1>
-                <div class="header-meta">
-                    <span class="meta-label">Game ID</span>
-                    <span id="game-id" class="meta-value">—</span>
+            <div class="header-left">
+                <div class="header-info">
+                    <h1 id="game-name"></h1>
+                    <div class="header-meta">
+                        <span class="meta-label">Game ID</span>
+                        <span id="game-id" class="meta-value">—</span>
+                    </div>
                 </div>
+                <nav class="action-row" id="action-bar" aria-label="Game actions">
+                    <button type="button" id="previous" class="btn btn-blue" aria-label="Previous">
+                        <span class="btn-icon" aria-hidden="true">
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+                                <path d="M15.75 19.5 8.25 12l7.5-7.5" />
+                            </svg>
+                        </span>
+                        <span class="btn-label">Previous</span>
+                    </button>
+                    <button type="button" id="next" class="btn btn-blue" aria-label="Next">
+                        <span class="btn-icon" aria-hidden="true">
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+                                <path d="m8.25 4.5 7.5 7.5-7.5 7.5" />
+                            </svg>
+                        </span>
+                        <span class="btn-label">Next</span>
+                    </button>
+                    <button type="button" id="save" class="btn btn-green" aria-label="Save">
+                        <span class="btn-icon" aria-hidden="true">
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+                                <path d="M5 3h10.5l3.5 3.5V21H5z" />
+                                <path d="M9 3v6h6V3" />
+                                <path d="M9 13h6v8H9z" />
+                            </svg>
+                        </span>
+                        <span class="btn-label">Save</span>
+                    </button>
+                    <button type="button" id="skip" class="btn btn-yellow" aria-label="Skip">
+                        <span class="btn-icon" aria-hidden="true">
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+                                <path d="m7 5 7 7-7 7" />
+                                <path d="M17 5v14" />
+                            </svg>
+                        </span>
+                        <span class="btn-label">Skip</span>
+                    </button>
+                    <button type="button" id="reset" class="btn btn-red" aria-label="Reset">
+                        <span class="btn-icon" aria-hidden="true">
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+                                <path d="M20 6a8 8 0 1 0 2.344 5.657" />
+                                <path d="M20 6h-5" />
+                                <path d="M20 6v5" />
+                            </svg>
+                        </span>
+                        <span class="btn-label">Reset</span>
+                    </button>
+                </nav>
             </div>
-            <div class="progress-indicator">
-                <div class="progress-metrics">
-                    <span id="progress-count" class="progress-count">0/0</span>
-                    <span id="progress-percent" class="progress-percent">0.00%</span>
+            <div class="header-right">
+                <div class="header-preview">
+                    <img id="preview" alt="Cropped preview" />
                 </div>
-                <div class="progress-bar"><div id="progress"></div></div>
+                <div class="progress-indicator">
+                    <div class="progress-metrics">
+                        <span id="progress-count" class="progress-count">0/0</span>
+                        <span id="progress-percent" class="progress-percent">0.00%</span>
+                    </div>
+                    <div class="progress-bar"><div id="progress"></div></div>
+                </div>
             </div>
         </div>
-        <nav class="action-row" id="action-bar" aria-label="Game actions">
-            <button type="button" id="previous" class="btn btn-blue">Previous</button>
-            <button type="button" id="next" class="btn btn-blue">Next</button>
-            <button type="button" id="save" class="btn btn-green">Save</button>
-            <button type="button" id="skip" class="btn btn-yellow">Skip</button>
-            <button type="button" id="reset" class="btn btn-red">Reset</button>
-        </nav>
     </header>
     <main class="editor-body">
         <section class="details-column">
@@ -45,10 +92,6 @@
                     <label>Title
                         <input type="text" id="name" autocomplete="off" />
                     </label>
-                    <div class="static-field">
-                        <span class="static-label">Game ID</span>
-                        <span id="game-id-display" class="static-value">—</span>
-                    </div>
                     <label>First Launch Date
                         <input type="text" id="first-launch" autocomplete="off" />
                     </label>
@@ -56,10 +99,7 @@
                 <div class="summary-section">
                     <div class="summary-header">
                         <label for="summary">Summary</label>
-                        <div class="summary-actions">
-                            <button type="button" id="expand-summary" class="btn btn-outline">Expand</button>
-                            <button type="button" id="generate-summary" class="btn btn-outline">Gerar Resumo</button>
-                        </div>
+                        <button type="button" id="generate-summary" class="btn btn-outline">Gerar Resumo</button>
                     </div>
                     <textarea id="summary"></textarea>
                 </div>
@@ -103,10 +143,6 @@
                 <div class="image-wrapper">
                     <img id="image" alt="Cover image workspace" />
                     <div id="image-resolution" class="resolution-label"></div>
-                </div>
-                <div class="preview-panel">
-                    <h3>Preview</h3>
-                    <img id="preview" alt="Cropped preview" />
                 </div>
             </div>
         </aside>


### PR DESCRIPTION
## Summary
- restructure the editor header to host the cropped preview beside the title and action bar
- streamline the form by removing the static Game ID field and summary expand control
- refresh styles and scripts for the new layout, add icon-based mobile navigation, and prevent the cropper from forcing page scroll

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8a2f817188333b69d3bfdeddbe57c