### PR TITLE
Use material icons and reposition preview

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -46,7 +46,6 @@ body {
 
 .header-main {
   display: flex;
-  justify-content: space-between;
   align-items: flex-start;
   gap: 32px;
 }
@@ -56,6 +55,7 @@ body {
   flex-direction: column;
   gap: 20px;
   min-width: 0;
+  flex: 1;
 }
 
 .header-right {
@@ -63,6 +63,8 @@ body {
   flex-direction: column;
   gap: 20px;
   align-items: flex-end;
+  margin-left: auto;
+  flex-shrink: 0;
 }
 
 .header-info h1 {
@@ -201,16 +203,20 @@ body {
 }
 
 .btn-icon {
-  width: 20px;
-  height: 20px;
+  width: 24px;
+  height: 24px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
 }
 
-.btn-icon svg {
-  width: 100%;
-  height: 100%;
+.btn-icon .material-symbols-rounded {
+  font-size: 22px;
+  line-height: 1;
+}
+
+.material-symbols-rounded {
+  font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
 }
 
 .btn-label {
@@ -561,12 +567,6 @@ textarea {
     gap: 20px;
   }
 
-  .header-right {
-    flex-direction: row;
-    align-items: center;
-    justify-content: space-between;
-  }
-
   .header-preview {
     width: 104px;
     height: 104px;
@@ -575,6 +575,11 @@ textarea {
   .progress-indicator {
     min-width: unset;
     align-items: flex-start;
+  }
+
+  .header-right {
+    align-items: flex-start;
+    margin-left: 0;
   }
 
   .action-row {

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/cropperjs@1.5.13/dist/cropper.min.css" />
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/choices.js/public/assets/styles/choices.min.css" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@20..48,400,0,0" />
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}" />
     <script src="https://cdn.jsdelivr.net/npm/cropperjs@1.5.13/dist/cropper.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/choices.js/public/assets/scripts/choices.min.js"></script>
@@ -15,6 +16,9 @@
     <div id="toast" role="status" aria-live="polite"></div>
     <header class="editor-header">
         <div class="header-main">
+            <div class="header-preview">
+                <img id="preview" alt="Cropped preview" />
+            </div>
             <div class="header-left">
                 <div class="header-info">
                     <h1 id="game-name"></h1>
@@ -26,55 +30,37 @@
                 <nav class="action-row" id="action-bar" aria-label="Game actions">
                     <button type="button" id="previous" class="btn btn-blue" aria-label="Previous">
                         <span class="btn-icon" aria-hidden="true">
-                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-                                <path d="M15.75 19.5 8.25 12l7.5-7.5" />
-                            </svg>
+                            <span class="material-symbols-rounded">arrow_back</span>
                         </span>
                         <span class="btn-label">Previous</span>
                     </button>
                     <button type="button" id="next" class="btn btn-blue" aria-label="Next">
                         <span class="btn-icon" aria-hidden="true">
-                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-                                <path d="m8.25 4.5 7.5 7.5-7.5 7.5" />
-                            </svg>
+                            <span class="material-symbols-rounded">arrow_forward</span>
                         </span>
                         <span class="btn-label">Next</span>
                     </button>
                     <button type="button" id="save" class="btn btn-green" aria-label="Save">
                         <span class="btn-icon" aria-hidden="true">
-                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-                                <path d="M5 3h10.5l3.5 3.5V21H5z" />
-                                <path d="M9 3v6h6V3" />
-                                <path d="M9 13h6v8H9z" />
-                            </svg>
+                            <span class="material-symbols-rounded">save</span>
                         </span>
                         <span class="btn-label">Save</span>
                     </button>
                     <button type="button" id="skip" class="btn btn-yellow" aria-label="Skip">
                         <span class="btn-icon" aria-hidden="true">
-                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-                                <path d="m7 5 7 7-7 7" />
-                                <path d="M17 5v14" />
-                            </svg>
+                            <span class="material-symbols-rounded">skip_next</span>
                         </span>
                         <span class="btn-label">Skip</span>
                     </button>
                     <button type="button" id="reset" class="btn btn-red" aria-label="Reset">
                         <span class="btn-icon" aria-hidden="true">
-                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-                                <path d="M20 6a8 8 0 1 0 2.344 5.657" />
-                                <path d="M20 6h-5" />
-                                <path d="M20 6v5" />
-                            </svg>
+                            <span class="material-symbols-rounded">refresh</span>
                         </span>
                         <span class="btn-label">Reset</span>
                     </button>
                 </nav>
             </div>
             <div class="header-right">
-                <div class="header-preview">
-                    <img id="preview" alt="Cropped preview" />
-                </div>
                 <div class="progress-indicator">
                     <div class="progress-metrics">
                         <span id="progress-count" class="progress-count">0/0</span>


### PR DESCRIPTION
## Summary
- switch navigation buttons to Material Symbols icons for consistent styling
- move the cropped preview to the left side of the header and adjust layout spacing
- update button icon styling to accommodate the new icon font

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8a89bca4c8333a8cde2520c9541d2