### PR TITLE
Align header preview beside game info

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -51,11 +51,23 @@ body {
 }
 
 .header-left {
-  display: flex;
-  flex-direction: column;
-  gap: 20px;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  column-gap: 24px;
+  row-gap: 20px;
+  align-items: start;
   min-width: 0;
   flex: 1;
+}
+
+.header-left .header-info {
+  grid-column: 2;
+  min-width: 0;
+}
+
+.header-left .action-row {
+  grid-column: 2;
+  align-self: start;
 }
 
 .header-right {
@@ -476,6 +488,9 @@ textarea {
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
+  grid-row: 1 / span 2;
+  align-self: start;
+  justify-self: start;
 }
 
 .header-preview img {
@@ -567,6 +582,12 @@ textarea {
     gap: 20px;
   }
 
+  .header-left {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+
   .header-preview {
     width: 104px;
     height: 104px;
@@ -586,6 +607,10 @@ textarea {
     flex-wrap: nowrap;
     justify-content: space-between;
     gap: 12px;
+  }
+
+  .header-left .action-row {
+    width: 100%;
   }
 
   .btn {

--- a/templates/index.html
+++ b/templates/index.html
@@ -16,10 +16,10 @@
     <div id="toast" role="status" aria-live="polite"></div>
     <header class="editor-header">
         <div class="header-main">
-            <div class="header-preview">
-                <img id="preview" alt="Cropped preview" />
-            </div>
             <div class="header-left">
+                <div class="header-preview">
+                    <img id="preview" alt="Cropped preview" />
+                </div>
                 <div class="header-info">
                     <h1 id="game-name"></h1>
                     <div class="header-meta">


### PR DESCRIPTION
## Summary
- reorganize the header markup so the preview image sits before the game info
- update header layout styles to use a two-column grid that keeps the buttons under the text
- adjust responsive rules to fall back to the stacked mobile layout

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8b9b27c6083338e47a26630b04232