### PR TITLE
feat: redesign login experience

### DIFF
--- a/static/login.css
+++ b/static/login.css
@@ -1,0 +1,252 @@
+:root {
+  color-scheme: dark;
+  --color-card: rgba(15, 23, 42, 0.58);
+  --color-card-strong: rgba(15, 23, 42, 0.7);
+  --color-border: rgba(226, 232, 240, 0.28);
+  --color-text: #f8fafc;
+  --color-muted: rgba(226, 232, 240, 0.75);
+  --color-focus-ring: rgba(94, 234, 212, 0.45);
+  --color-focus-border: rgba(148, 163, 184, 0.85);
+  --color-button-start: #1e3a8a;
+  --color-button-end: #3b82f6;
+  --color-button-shadow: rgba(15, 23, 42, 0.55);
+  --color-toggle-bg: rgba(15, 23, 42, 0.4);
+  --color-toggle-border: rgba(148, 163, 184, 0.45);
+  --glow-outer: 0 28px 60px rgba(4, 12, 30, 0.6);
+  font-size: clamp(15px, 1vw + 14px, 18px);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: stretch;
+  justify-content: center;
+  font-family: "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
+  color: var(--color-text);
+  background-image: url('/home.jpg');
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+  position: relative;
+  line-height: 1.6;
+  overflow-x: hidden;
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background: linear-gradient(
+    180deg,
+    rgba(2, 6, 23, 0.78) 0%,
+    rgba(2, 6, 23, 0.72) 38%,
+    rgba(8, 15, 35, 0.8) 100%
+  );
+  pointer-events: none;
+  z-index: 0;
+}
+
+main {
+  position: relative;
+  z-index: 1;
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(1.5rem, 6vw, 3.75rem) clamp(1rem, 5vw, 3rem);
+}
+
+.login-card {
+  width: min(92vw, 420px);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.25rem, 4vw, 2.25rem);
+  padding: clamp(1.75rem, 5vw, 2.5rem);
+  border-radius: 24px;
+  border: 1px solid var(--color-border);
+  background: linear-gradient(145deg, var(--color-card), var(--color-card-strong));
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  box-shadow: var(--glow-outer), 0 0 0 1px rgba(148, 163, 184, 0.12);
+}
+
+.login-card > header {
+  text-align: center;
+}
+
+.login-card h1 {
+  margin: 0;
+  font-size: clamp(2rem, 6vw, 2.6rem);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.login-subtext {
+  margin: 0;
+  font-size: clamp(0.95rem, 2vw, 1.05rem);
+  color: var(--color-muted);
+}
+
+form {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1rem, 3.5vw, 1.75rem);
+}
+
+label {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  font-size: clamp(0.95rem, 1vw + 0.85rem, 1.05rem);
+  font-weight: 500;
+}
+
+.field-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.input-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: clamp(0.75rem, 3vw, 1rem) clamp(0.85rem, 3vw, 1.15rem);
+  border-radius: 18px;
+  background: rgba(15, 23, 42, 0.35);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  transition: border-color 160ms ease, box-shadow 160ms ease, background-color 160ms ease;
+}
+
+.input-wrapper:focus-within {
+  border-color: var(--color-focus-border);
+  background: rgba(15, 23, 42, 0.55);
+  box-shadow: 0 0 0 3px var(--color-focus-ring), 0 18px 40px rgba(8, 14, 35, 0.45);
+}
+
+.field-icon {
+  display: inline-flex;
+  width: 24px;
+  height: 24px;
+  color: var(--color-muted);
+}
+
+.field-icon svg {
+  width: 100%;
+  height: 100%;
+}
+
+input[type="password"],
+input[type="text"] {
+  flex: 1;
+  border: none;
+  background: transparent;
+  color: var(--color-text);
+  font-size: clamp(1rem, 1vw + 0.9rem, 1.1rem);
+  font-weight: 500;
+  line-height: 1.4;
+  min-width: 0;
+}
+
+input[type="password"]::placeholder,
+input[type="text"]::placeholder {
+  color: rgba(226, 232, 240, 0.45);
+}
+
+input[type="password"]:focus,
+input[type="text"]:focus {
+  outline: none;
+}
+
+.toggle-password {
+  appearance: none;
+  border: 1px solid transparent;
+  background: var(--color-toggle-bg);
+  color: var(--color-text);
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  border-radius: 999px;
+  padding: 0.45rem 0.85rem;
+  cursor: pointer;
+  transition: background-color 160ms ease, border-color 160ms ease, color 160ms ease;
+}
+
+.toggle-password:hover {
+  background: rgba(148, 163, 184, 0.3);
+}
+
+.toggle-password:focus-visible {
+  outline: 3px solid var(--color-focus-ring);
+  outline-offset: 3px;
+  border-color: var(--color-toggle-border);
+}
+
+button[type="submit"] {
+  border: none;
+  border-radius: 999px;
+  padding: clamp(0.85rem, 3vw, 1.05rem);
+  font-size: clamp(1rem, 1vw + 0.95rem, 1.15rem);
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-text);
+  background: linear-gradient(135deg, var(--color-button-start), var(--color-button-end));
+  box-shadow: 0 18px 36px var(--color-button-shadow);
+  cursor: pointer;
+  transition: transform 160ms ease, box-shadow 160ms ease, filter 160ms ease;
+}
+
+button[type="submit"]:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+button[type="submit"]:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 22px 45px rgba(11, 19, 43, 0.65);
+}
+
+button[type="submit"]:focus-visible {
+  outline: 3px solid var(--color-focus-ring);
+  outline-offset: 4px;
+}
+
+.form-error {
+  margin: 0;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  background: rgba(248, 113, 113, 0.12);
+  border: 1px solid rgba(248, 113, 113, 0.25);
+  color: #fecaca;
+  font-size: clamp(0.9rem, 1vw + 0.8rem, 1rem);
+}
+
+@media (min-width: 768px) {
+  :root {
+    --glow-outer: 0 38px 120px rgba(4, 12, 30, 0.7);
+  }
+
+  .login-card {
+    padding: clamp(2.5rem, 3.5vw, 3rem);
+    background: linear-gradient(150deg, rgba(15, 23, 42, 0.6), rgba(15, 23, 42, 0.72));
+    box-shadow: var(--glow-outer), 0 0 0 1px rgba(148, 163, 184, 0.14);
+  }
+}
+
+@media (max-width: 360px) {
+  .input-wrapper {
+    padding: 0.75rem 0.85rem;
+  }
+
+  .toggle-password {
+    padding: 0.4rem 0.7rem;
+  }
+}

--- a/static/login.js
+++ b/static/login.js
@@ -1,0 +1,36 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const passwordInput = document.getElementById('password');
+  const toggleButton = document.querySelector('[data-toggle-password]');
+  const submitButton = document.querySelector('[data-login-submit]');
+
+  if (!passwordInput || !submitButton) {
+    return;
+  }
+
+  const updateSubmitState = () => {
+    const hasValue = passwordInput.value.trim().length > 0;
+    submitButton.disabled = !hasValue;
+  };
+
+  updateSubmitState();
+  passwordInput.addEventListener('input', updateSubmitState);
+
+  if (toggleButton) {
+    toggleButton.addEventListener('click', (event) => {
+      event.preventDefault();
+      const isPassword = passwordInput.getAttribute('type') === 'password';
+      passwordInput.setAttribute('type', isPassword ? 'text' : 'password');
+      toggleButton.setAttribute('aria-pressed', String(isPassword));
+      toggleButton.setAttribute('aria-label', isPassword ? 'Hide password' : 'Show password');
+      const toggleText = toggleButton.querySelector('.toggle-text');
+      if (toggleText) {
+        toggleText.textContent = isPassword ? 'Hide' : 'Show';
+      }
+      passwordInput.focus();
+      if (typeof passwordInput.setSelectionRange === 'function') {
+        const length = passwordInput.value.length;
+        passwordInput.setSelectionRange(length, length);
+      }
+    });
+  }
+});

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,17 +1,47 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Login</title>
-    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='login.css') }}" />
 </head>
 <body>
-    <form method="post">
-        {% if error %}<p>{{ error }}</p>{% endif %}
-        <label>Password
-            <input type="password" name="password" />
-        </label>
-        <button type="submit">Login</button>
-    </form>
+    <main>
+        <section class="login-card" role="region" aria-labelledby="login-title">
+            <header>
+                <h1 id="login-title">Login</h1>
+            </header>
+            <form method="post">
+                {% if error %}
+                <p class="form-error" id="form-error" role="alert">{{ error }}</p>
+                {% endif %}
+                <div class="field-group">
+                    <label for="password">Password</label>
+                    <div class="input-wrapper">
+                        <span class="field-icon" aria-hidden="true">
+                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 10-9 0v3.75M6.75 10.5h10.5A2.25 2.25 0 0119.5 12.75v6a2.25 2.25 0 01-2.25 2.25H6.75A2.25 2.25 0 014.5 18.75v-6A2.25 2.25 0 016.75 10.5z" />
+                            </svg>
+                        </span>
+                        <input
+                            type="password"
+                            id="password"
+                            name="password"
+                            autocomplete="current-password"
+                            required
+                            placeholder="Enter your password"
+                            {% if error %}aria-invalid="true" aria-describedby="form-error"{% endif %}
+                        />
+                        <button type="button" class="toggle-password" data-toggle-password aria-label="Show password" aria-pressed="false">
+                            <span class="toggle-text">Show</span>
+                        </button>
+                    </div>
+                </div>
+                <button type="submit" data-login-submit disabled>Login</button>
+            </form>
+        </section>
+    </main>
+    <script src="{{ url_for('static', filename='login.js') }}" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- restyled the login template with a centered glassmorphism card and accessible password field
- added a dedicated responsive stylesheet with fluid spacing, gradient overlay, and background image treatment
- introduced a small script to toggle password visibility and enable the login button once input is provided

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8c3ddf0e883338d636bd2bc216ad2