### PR TITLE
Set login background image via template

### DIFF
--- a/static/login.css
+++ b/static/login.css
@@ -28,7 +28,6 @@ body {
   justify-content: center;
   font-family: "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
   color: var(--color-text);
-  background-image: url('/static/home.jpg');
   background-size: cover;
   background-position: center;
   background-repeat: no-repeat;

--- a/templates/login.html
+++ b/templates/login.html
@@ -5,6 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Login</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='login.css') }}" />
+    <style>
+        body {
+            background-image: url("{{ url_for('static', filename='home.jpg') }}");
+        }
+    </style>
 </head>
 <body>
     <main>


### PR DESCRIPTION
## Summary
- set the login page background image through an inline style that uses `url_for`
- remove the hard-coded background image from the login stylesheet

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8d0384ef083339c16999e1aa553f6