### PR TITLE
Adjust login background overlay opacity

### DIFF
--- a/static/login.css
+++ b/static/login.css
@@ -42,9 +42,9 @@ body::before {
   inset: 0;
   background: linear-gradient(
     180deg,
-    rgba(2, 6, 23, 0.78) 0%,
-    rgba(2, 6, 23, 0.72) 38%,
-    rgba(8, 15, 35, 0.8) 100%
+    rgba(2, 6, 23, 0.38) 0%,
+    rgba(2, 6, 23, 0.34) 38%,
+    rgba(8, 15, 35, 0.4) 100%
   );
   pointer-events: none;
   z-index: 0;


### PR DESCRIPTION
## Summary
- lower the alpha levels in the login page background gradient overlay to reduce opacity

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8d4a998f48333a505095d60f190f4