### PR TITLE
Add jump-to-ID navigation with backend support

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -94,6 +94,32 @@ body {
   color: var(--color-muted);
 }
 
+.jump-form {
+  margin-top: 12px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.jump-controls {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.jump-controls input {
+  width: 120px;
+  padding: 10px 12px;
+  border-radius: 8px;
+  font-size: 0.95rem;
+}
+
+.jump-controls input:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
 .meta-label {
   text-transform: uppercase;
   letter-spacing: 0.08em;

--- a/templates/index.html
+++ b/templates/index.html
@@ -26,6 +26,21 @@
                         <span class="meta-label">Game ID</span>
                         <span id="game-id" class="meta-value">—</span>
                     </div>
+                    <form id="jump-form" class="jump-form" autocomplete="off" aria-label="Go to game by ID">
+                        <span class="meta-label">Go to ID</span>
+                        <div class="jump-controls">
+                            <input
+                                type="text"
+                                id="jump-input"
+                                inputmode="numeric"
+                                pattern="[0-9]*"
+                                autocomplete="off"
+                                placeholder="e.g. 42"
+                                aria-label="Enter a game ID to jump to"
+                            />
+                            <button type="submit" id="jump-submit" class="btn btn-outline">Go</button>
+                        </div>
+                    </form>
                 </div>
                 <nav class="action-row" id="action-bar" aria-label="Game actions">
                     <button type="button" id="previous" class="btn btn-blue" aria-label="Previous">

--- a/tests/test_api_game_by_id.py
+++ b/tests/test_api_game_by_id.py
@@ -1,0 +1,92 @@
+import os
+import uuid
+import importlib.util
+from pathlib import Path
+
+import pandas as pd
+
+APP_PATH = Path(__file__).resolve().parents[1] / "app.py"
+
+
+def load_app(tmp_path):
+    os.chdir(tmp_path)
+    module_name = f"app_{uuid.uuid4().hex}"
+    spec = importlib.util.spec_from_file_location(module_name, APP_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def seed_games(app_module):
+    app_module.games_df = pd.DataFrame(
+        [
+            {
+                "Name": "Catalogued Game",
+                "Summary": "",
+                "First Launch Date": "",
+                "Developers": "",
+                "Publishers": "",
+                "Genres": "",
+                "Game Modes": "",
+                "Category": "",
+                "Platforms": "",
+                "Large Cover Image (URL)": "",
+            }
+        ]
+    )
+    app_module.total_games = len(app_module.games_df)
+    app_module.navigator.total = app_module.total_games
+
+
+def authenticate(client):
+    with client.session_transaction() as sess:
+        sess['authenticated'] = True
+
+
+def test_game_by_id_returns_payload(tmp_path):
+    app_module = load_app(tmp_path)
+    seed_games(app_module)
+    upload_dir = Path(tmp_path) / app_module.UPLOAD_DIR
+    upload_dir.mkdir(parents=True, exist_ok=True)
+    temp_name = "temp_upload.jpg"
+    (upload_dir / temp_name).write_text("temp")
+    with app_module.db_lock:
+        with app_module.db:
+            app_module.db.execute(
+                'INSERT INTO processed_games ("ID", "Source Index", "Name") VALUES (?, ?, ?)',
+                (1, '0', 'Catalogued Game'),
+            )
+    app_module.navigator.current_index = 1
+    client = app_module.app.test_client()
+    authenticate(client)
+    response = client.post(
+        '/api/game_by_id',
+        json={'id': 1, 'upload_name': temp_name},
+    )
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data['index'] == 0
+    assert data['id'] == 1
+    assert data['game']['Name'] == 'Catalogued Game'
+    assert app_module.navigator.current_index == 0
+    assert not (upload_dir / temp_name).exists()
+
+
+def test_game_by_id_not_found(tmp_path):
+    app_module = load_app(tmp_path)
+    seed_games(app_module)
+    client = app_module.app.test_client()
+    authenticate(client)
+    response = client.post('/api/game_by_id', json={'id': 999})
+    assert response.status_code == 404
+    assert response.get_json()['error'] == 'id not found'
+
+
+def test_game_by_id_invalid_input(tmp_path):
+    app_module = load_app(tmp_path)
+    client = app_module.app.test_client()
+    authenticate(client)
+    response = client.post('/api/game_by_id', json={'id': 'abc'})
+    assert response.status_code == 400
+    assert response.get_json()['error'] == 'invalid id'
+


### PR DESCRIPTION
## Summary
- add a dedicated `/api/game_by_id` endpoint that validates requests, aligns the navigator with the requested ID, and returns the standard payload
- surface a "Go to ID" control in the editor header with supporting JavaScript that reuses the existing navigation flow and guards against invalid input
- cover the new endpoint with pytest to confirm success, error handling, and cleanup behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf6c9f3ed483338cddf504f32fb8f5