### PR TITLE
Add IGDB updates tracking and API

### DIFF
--- a/templates/updates.html
+++ b/templates/updates.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>IGDB Updates</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}" />
+</head>
+<body>
+    <main class="updates-container">
+        <header>
+            <h1>IGDB Updates</h1>
+            <p>This page uses the updates API to populate data.</p>
+        </header>
+        <section aria-live="polite" id="updates-root"></section>
+    </main>
+</body>
+</html>

--- a/tests/test_updates_api.py
+++ b/tests/test_updates_api.py
@@ -1,0 +1,158 @@
+import os
+import uuid
+import importlib.util
+from pathlib import Path
+
+APP_PATH = Path(__file__).resolve().parents[1] / "app.py"
+
+
+def load_app(tmp_path):
+    os.chdir(tmp_path)
+    module_name = f"app_{uuid.uuid4().hex}"
+    spec = importlib.util.spec_from_file_location(module_name, APP_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def authenticate(client):
+    with client.session_transaction() as sess:
+        sess['authenticated'] = True
+
+
+def insert_processed_game(app_module, **overrides):
+    defaults = {
+        "ID": 1,
+        "Source Index": "0",
+        "Name": "Local Game",
+        "Summary": "Local summary",
+        "First Launch Date": "2020-01-01",
+        "Developers": "Local Dev",
+        "Publishers": "Local Pub",
+        "Genres": "Action",
+        "Game Modes": "Single-player",
+        "Category": "Main",
+        "Platforms": "PC",
+        "igdb_id": "100",
+        "Cover Path": "",
+        "Width": 0,
+        "Height": 0,
+        "last_edited_at": "2024-01-01T00:00:00+00:00",
+    }
+    defaults.update(overrides)
+    with app_module.db_lock:
+        with app_module.db:
+            app_module.db.execute(
+                '''INSERT INTO processed_games (
+                    "ID", "Source Index", "Name", "Summary",
+                    "First Launch Date", "Developers", "Publishers",
+                    "Genres", "Game Modes", "Category", "Platforms",
+                    "igdb_id", "Cover Path", "Width", "Height", last_edited_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)''',
+                (
+                    defaults["ID"],
+                    defaults["Source Index"],
+                    defaults["Name"],
+                    defaults["Summary"],
+                    defaults["First Launch Date"],
+                    defaults["Developers"],
+                    defaults["Publishers"],
+                    defaults["Genres"],
+                    defaults["Game Modes"],
+                    defaults["Category"],
+                    defaults["Platforms"],
+                    defaults["igdb_id"],
+                    defaults["Cover Path"],
+                    defaults["Width"],
+                    defaults["Height"],
+                    defaults["last_edited_at"],
+                ),
+            )
+
+
+def test_refresh_creates_update_records(tmp_path):
+    app_module = load_app(tmp_path)
+    insert_processed_game(app_module)
+    client = app_module.app.test_client()
+    authenticate(client)
+
+    captured_ids = []
+
+    def fake_exchange():
+        return "token", "client"
+
+    def fake_fetch(token, client_id, igdb_ids):
+        captured_ids.extend(igdb_ids)
+        return {
+            "100": {
+                "id": 100,
+                "updated_at": 1_700_000_000,
+                "summary": "Remote summary",
+                "genres": ["Action", "Adventure"],
+                "platforms": ["PC", "Switch"],
+            }
+        }
+
+    app_module.exchange_twitch_credentials = fake_exchange
+    app_module.fetch_igdb_metadata = fake_fetch
+
+    refresh = client.post('/api/updates/refresh')
+    assert refresh.status_code == 200
+    data = refresh.get_json()
+    assert data['status'] == 'ok'
+    assert data['updated'] == 1
+    assert data['missing'] == []
+    assert captured_ids == ['100']
+
+    listing = client.get('/api/updates')
+    assert listing.status_code == 200
+    listing_data = listing.get_json()
+    assert listing_data['updates']
+    entry = listing_data['updates'][0]
+    assert entry['processed_game_id'] == 1
+    assert entry['igdb_id'] == '100'
+    assert entry['name'] == 'Local Game'
+    assert entry['has_diff'] is True
+
+
+def test_updates_detail_returns_diff(tmp_path):
+    app_module = load_app(tmp_path)
+    insert_processed_game(app_module)
+    client = app_module.app.test_client()
+    authenticate(client)
+
+    app_module.exchange_twitch_credentials = lambda: ("token", "client")
+
+    def fake_fetch(token, client_id, igdb_ids):
+        return {
+            "100": {
+                "id": 100,
+                "updated_at": 1_700_000_000,
+                "summary": "Remote summary",
+                "genres": ["Action", "Adventure"],
+                "platforms": ["PC", "Switch"],
+            }
+        }
+
+    app_module.fetch_igdb_metadata = fake_fetch
+
+    refresh = client.post('/api/updates/refresh')
+    assert refresh.status_code == 200
+
+    detail = client.get('/api/updates/1')
+    assert detail.status_code == 200
+    payload = detail.get_json()
+    assert payload['igdb_payload']['summary'] == 'Remote summary'
+    assert payload['diff']['Summary']['added'] == 'Remote summary'
+    assert 'Adventure' in payload['diff']['Genres']['added']
+    assert payload['processed_game_id'] == 1
+    assert payload['igdb_id'] == '100'
+
+
+def test_updates_detail_missing_returns_404(tmp_path):
+    app_module = load_app(tmp_path)
+    client = app_module.app.test_client()
+    authenticate(client)
+    response = client.get('/api/updates/999')
+    assert response.status_code == 404
+    assert response.get_json()['error'] == 'not found'


### PR DESCRIPTION
## Summary
- add database migrations for tracking last edited time and IGDB update snapshots
- implement Twitch/IGDB helpers, diffing logic, and authenticated update routes
- add updates template plus tests covering refresh, listing, and diff retrieval

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d093f60b9483338e0db79a8ba4c1ef