### PR TITLE
Add IGDB updates dashboard and navigation

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -11,6 +11,7 @@
   --color-red: #ef4444;
   --color-outline: rgba(255, 255, 255, 0.12);
   --shadow-soft: 0 12px 32px rgba(8, 15, 35, 0.45);
+  --topbar-height: 0px;
 }
 
 * {
@@ -34,9 +35,90 @@ body {
   flex-direction: column;
 }
 
-.editor-header {
+body.page-editor,
+body.page-updates {
+  --topbar-height: 64px;
+}
+
+body.page-updates {
+  overflow: auto;
+}
+
+body.modal-open {
+  overflow: hidden;
+}
+
+.app-topbar {
   position: sticky;
   top: 0;
+  z-index: 40;
+  display: flex;
+  align-items: center;
+  background: rgba(15, 23, 42, 0.95);
+  backdrop-filter: blur(8px);
+  padding: 14px 32px;
+  box-shadow: 0 6px 18px rgba(8, 14, 32, 0.35);
+}
+
+.topbar-content {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  gap: 24px;
+}
+
+.topbar-brand {
+  font-weight: 600;
+  font-size: 1.1rem;
+  color: var(--color-text);
+  text-decoration: none;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.topbar-nav {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+}
+
+.topbar-link {
+  color: var(--color-muted);
+  text-decoration: none;
+  font-weight: 500;
+  font-size: 0.95rem;
+  padding-bottom: 4px;
+  border-bottom: 2px solid transparent;
+  transition: color 120ms ease, border-color 120ms ease;
+}
+
+.topbar-link:hover,
+.topbar-link:focus-visible {
+  color: var(--color-text);
+  border-color: rgba(37, 99, 235, 0.4);
+}
+
+.topbar-link.is-active {
+  color: var(--color-text);
+  border-color: var(--color-blue);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.editor-header {
+  position: sticky;
+  top: var(--topbar-height, 0);
   z-index: 30;
   background: linear-gradient(180deg, rgba(15, 23, 42, 0.95), rgba(21, 34, 56, 0.95));
   backdrop-filter: blur(8px);
@@ -571,6 +653,392 @@ textarea {
 
 .cropper-dashed {
   border-color: var(--color-yellow) !important;
+}
+
+.updates-page {
+  width: min(1180px, 100% - 48px);
+  margin: 32px auto 64px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.updates-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.updates-title h1 {
+  margin: 0;
+  font-size: 2rem;
+  font-weight: 500;
+}
+
+.updates-title p {
+  margin: 8px 0 0;
+  color: var(--color-muted);
+  max-width: 720px;
+}
+
+.updates-actions {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.updates-search {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 18px;
+  border-radius: 12px;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-elevated);
+  color: var(--color-muted);
+  min-width: 260px;
+}
+
+.updates-search input {
+  border: none;
+  background: transparent;
+  color: var(--color-text);
+  font-size: 0.95rem;
+  outline: none;
+  width: 100%;
+}
+
+.updates-search input::placeholder {
+  color: rgba(226, 232, 240, 0.5);
+}
+
+.updates-summary {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 0.95rem;
+  color: var(--color-muted);
+}
+
+.updates-summary strong {
+  color: var(--color-text);
+  font-size: 1rem;
+}
+
+.updates-status {
+  color: var(--color-muted);
+}
+
+.updates-table-card {
+  background: var(--color-surface-elevated);
+  border-radius: 20px;
+  border: 1px solid var(--color-border);
+  box-shadow: 0 16px 40px rgba(8, 15, 35, 0.45);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.table-scroll {
+  overflow-x: auto;
+}
+
+.updates-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 720px;
+}
+
+.updates-table thead {
+  background: rgba(15, 23, 42, 0.3);
+}
+
+.updates-table th,
+.updates-table td {
+  padding: 16px 20px;
+  text-align: left;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.1);
+}
+
+.updates-table th {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-muted);
+}
+
+.updates-table tbody tr {
+  transition: background 120ms ease;
+}
+
+.updates-table tbody tr:hover {
+  background: rgba(37, 99, 235, 0.08);
+}
+
+.updates-table tbody tr.has-diff {
+  box-shadow: inset 4px 0 0 rgba(37, 99, 235, 0.65);
+}
+
+.cell-primary {
+  font-weight: 500;
+}
+
+.actions-column,
+.actions-cell {
+  text-align: right;
+  white-space: nowrap;
+}
+
+.actions-cell {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.icon-button {
+  width: 40px;
+  height: 40px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 12px;
+  border: 1px solid transparent;
+  background: rgba(148, 163, 184, 0.08);
+  color: var(--color-text);
+  cursor: pointer;
+  transition: background 120ms ease, border-color 120ms ease, transform 120ms ease;
+}
+
+.icon-button:hover,
+.icon-button:focus-visible {
+  background: rgba(37, 99, 235, 0.18);
+  border-color: rgba(37, 99, 235, 0.35);
+}
+
+.icon-button:active {
+  transform: scale(0.96);
+}
+
+.icon-button .material-symbols-rounded {
+  font-size: 1.4rem;
+}
+
+.table-empty,
+.table-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 28px;
+  color: var(--color-muted);
+  font-size: 0.95rem;
+}
+
+.table-loading .material-symbols-rounded {
+  animation: spin 1.4s linear infinite;
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.sort-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: none;
+  border: none;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  padding: 0;
+}
+
+.sort-button.is-active {
+  color: var(--color-text);
+}
+
+.sort-indicator {
+  font-size: 1.1rem;
+}
+
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(2, 10, 24, 0.78);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 32px;
+  z-index: 60;
+}
+
+.modal-backdrop.hidden {
+  display: none;
+}
+
+.modal-dialog {
+  width: min(900px, 100%);
+  max-height: 90vh;
+  background: var(--color-surface-elevated);
+  border-radius: 24px;
+  border: 1px solid var(--color-border);
+  box-shadow: 0 24px 48px rgba(4, 8, 20, 0.6);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.modal-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 24px 28px 0;
+}
+
+.modal-titles h2 {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 500;
+}
+
+.modal-subtitle {
+  margin: 6px 0 0;
+  color: var(--color-muted);
+  font-size: 0.95rem;
+}
+
+.modal-meta {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 12px;
+  padding: 20px 28px 0;
+}
+
+.modal-body {
+  padding: 24px 28px 32px;
+  overflow-y: auto;
+}
+
+.modal-empty {
+  color: var(--color-muted);
+}
+
+.diff-list {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.diff-field {
+  background: rgba(15, 23, 42, 0.4);
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  padding: 18px 20px;
+}
+
+.diff-field h3 {
+  margin: 0 0 12px;
+  font-size: 1rem;
+}
+
+.diff-columns {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 16px;
+}
+
+.diff-column h4 {
+  margin: 0 0 8px;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-muted);
+}
+
+.diff-value {
+  margin: 0;
+  white-space: pre-wrap;
+  line-height: 1.6;
+}
+
+.diff-empty {
+  color: var(--color-muted);
+}
+
+.diff-pills {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.diff-pill {
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  background: rgba(148, 163, 184, 0.12);
+  border: 1px solid transparent;
+}
+
+.diff-added {
+  color: var(--color-green);
+  border-color: rgba(34, 197, 94, 0.35);
+  background: rgba(34, 197, 94, 0.14);
+}
+
+.diff-removed {
+  color: var(--color-red);
+  border-color: rgba(239, 68, 68, 0.35);
+  background: rgba(239, 68, 68, 0.12);
+}
+
+@media (max-width: 900px) {
+  .updates-page {
+    width: calc(100% - 32px);
+    margin: 24px auto 48px;
+  }
+
+  .updates-table {
+    min-width: 640px;
+  }
+
+  .modal-dialog {
+    border-radius: 18px;
+  }
+}
+
+@media (max-width: 640px) {
+  .updates-actions {
+    width: 100%;
+  }
+
+  .updates-search {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .updates-table {
+    min-width: 560px;
+  }
+
+  .modal-header,
+  .modal-meta,
+  .modal-body {
+    padding-left: 20px;
+    padding-right: 20px;
+  }
 }
 
 #toast {

--- a/static/updates.js
+++ b/static/updates.js
@@ -1,0 +1,622 @@
+(function () {
+    const config = window.updatesConfig || {};
+    const state = {
+        updates: [],
+        filtered: [],
+        sortKey: 'refreshed_at',
+        sortDir: 'desc',
+        searchTerm: '',
+        detailCache: new Map(),
+        updateMap: new Map(),
+    };
+
+    const elements = {
+        tableBody: document.querySelector('[data-updates-body]'),
+        emptyState: document.querySelector('[data-empty-state]'),
+        loadingState: document.querySelector('[data-loading-state]'),
+        searchInput: document.querySelector('[data-search]'),
+        refreshButton: document.querySelector('[data-refresh]'),
+        countLabel: document.querySelector('[data-count]'),
+        statusLabel: document.querySelector('[data-refresh-status]'),
+        sortButtons: Array.from(document.querySelectorAll('.sort-button[data-sort]')),
+    };
+
+    const modal = {
+        backdrop: document.querySelector('[data-modal]'),
+        closeButton: document.querySelector('[data-close-modal]'),
+        subtitle: document.querySelector('[data-modal-subtitle]'),
+        gameId: document.querySelector('[data-modal-game-id]'),
+        igdbId: document.querySelector('[data-modal-igdb-id]'),
+        igdbUpdated: document.querySelector('[data-modal-igdb-updated]'),
+        localEdited: document.querySelector('[data-modal-local-edited]'),
+        empty: document.querySelector('[data-modal-empty]'),
+        diffList: document.querySelector('[data-diff-list]'),
+    };
+
+    const modalEmptyDefaultText = modal.empty ? modal.empty.textContent : '';
+    const toast = document.getElementById('toast');
+    let toastTimer = null;
+    let lastFocusedElement = null;
+
+    function showToast(message, type = 'success') {
+        if (!toast) {
+            return;
+        }
+        const normalized = type === 'error' ? 'warning' : type;
+        toast.textContent = message;
+        toast.className = '';
+        void toast.offsetWidth;
+        toast.classList.add(normalized, 'show');
+        clearTimeout(toastTimer);
+        toastTimer = setTimeout(() => {
+            toast.classList.remove('show');
+        }, 3200);
+    }
+
+    function parseDate(value) {
+        if (!value) {
+            return null;
+        }
+        const date = new Date(value);
+        if (Number.isNaN(date.getTime())) {
+            return null;
+        }
+        return date;
+    }
+
+    function formatDate(value) {
+        if (!value) {
+            return '—';
+        }
+        const date = parseDate(value);
+        if (!date) {
+            return value;
+        }
+        return new Intl.DateTimeFormat(undefined, {
+            dateStyle: 'medium',
+            timeStyle: 'short',
+        }).format(date);
+    }
+
+    function buildEditUrl(gameId) {
+        const base = config.editBaseUrl || '/';
+        try {
+            const url = new URL(base, window.location.origin);
+            url.searchParams.set('game_id', gameId);
+            return url.pathname + url.search + url.hash;
+        } catch (err) {
+            const separator = base.includes('?') ? '&' : '?';
+            return `${base}${separator}game_id=${encodeURIComponent(gameId)}`;
+        }
+    }
+
+    function setLoading(loading) {
+        if (!elements.loadingState || !elements.tableBody) {
+            return;
+        }
+        if (loading) {
+            elements.loadingState.hidden = false;
+            elements.tableBody.innerHTML = '';
+            if (elements.emptyState) {
+                elements.emptyState.hidden = true;
+            }
+        } else {
+            elements.loadingState.hidden = true;
+        }
+    }
+
+    function updateCount() {
+        if (!elements.countLabel) {
+            return;
+        }
+        elements.countLabel.textContent = String(state.filtered.length);
+    }
+
+    function updateStatusMessage() {
+        if (!elements.statusLabel) {
+            return;
+        }
+        if (state.searchTerm) {
+            const count = state.filtered.length;
+            const plural = count === 1 ? '' : 's';
+            elements.statusLabel.textContent = `Showing ${count} result${plural} for “${state.searchTerm}”.`;
+            return;
+        }
+        const latest = state.updates.reduce((acc, item) => {
+            const date = parseDate(item.refreshed_at || item.igdb_updated_at || item.local_last_edited_at);
+            if (!date) {
+                return acc;
+            }
+            if (!acc) {
+                return date;
+            }
+            return date > acc ? date : acc;
+        }, null);
+        if (latest) {
+            elements.statusLabel.textContent = `Last refreshed ${formatDate(latest.toISOString())}`;
+        } else {
+            elements.statusLabel.textContent = '';
+        }
+    }
+
+    function compareValues(a, b, key) {
+        switch (key) {
+            case 'name': {
+                const first = (a.name || '').toLocaleLowerCase();
+                const second = (b.name || '').toLocaleLowerCase();
+                if (first < second) return -1;
+                if (first > second) return 1;
+                return 0;
+            }
+            case 'processed_game_id': {
+                const first = Number.parseInt(a.processed_game_id, 10) || 0;
+                const second = Number.parseInt(b.processed_game_id, 10) || 0;
+                return first - second;
+            }
+            case 'refreshed_at':
+            default: {
+                const first = parseDate(a.refreshed_at) || parseDate(a.igdb_updated_at) || parseDate(a.local_last_edited_at);
+                const second = parseDate(b.refreshed_at) || parseDate(b.igdb_updated_at) || parseDate(b.local_last_edited_at);
+                if (!first && !second) return 0;
+                if (!first) return -1;
+                if (!second) return 1;
+                return first.getTime() - second.getTime();
+            }
+        }
+    }
+
+    function applyFilters() {
+        const term = state.searchTerm.trim().toLocaleLowerCase();
+        const filtered = term
+            ? state.updates.filter((item) => {
+                  const name = (item.name || '').toLocaleLowerCase();
+                  const id = String(item.processed_game_id || '');
+                  const igdbId = String(item.igdb_id || '');
+                  return name.includes(term) || id.includes(term) || igdbId.includes(term);
+              })
+            : state.updates.slice();
+
+        filtered.sort((a, b) => {
+            const comparison = compareValues(a, b, state.sortKey);
+            return state.sortDir === 'asc' ? comparison : -comparison;
+        });
+
+        state.filtered = filtered;
+        updateCount();
+        renderTable();
+        updateStatusMessage();
+    }
+
+    function createIcon(content, className) {
+        const span = document.createElement('span');
+        span.className = className;
+        span.setAttribute('aria-hidden', 'true');
+        span.textContent = content;
+        return span;
+    }
+
+    function renderTable() {
+        if (!elements.tableBody || !elements.emptyState) {
+            return;
+        }
+        elements.tableBody.innerHTML = '';
+        if (!state.filtered.length) {
+            elements.emptyState.hidden = false;
+            return;
+        }
+        elements.emptyState.hidden = true;
+        const fragment = document.createDocumentFragment();
+        state.filtered.forEach((item) => {
+            const row = document.createElement('tr');
+            row.classList.toggle('has-diff', Boolean(item.has_diff));
+
+            const refreshedCell = document.createElement('td');
+            refreshedCell.textContent = formatDate(item.refreshed_at || item.igdb_updated_at);
+            row.appendChild(refreshedCell);
+
+            const nameCell = document.createElement('td');
+            nameCell.className = 'cell-primary';
+            nameCell.textContent = item.name || 'Unnamed game';
+            row.appendChild(nameCell);
+
+            const idCell = document.createElement('td');
+            idCell.textContent = item.processed_game_id ? String(item.processed_game_id) : '—';
+            row.appendChild(idCell);
+
+            const igdbCell = document.createElement('td');
+            igdbCell.textContent = item.igdb_id ? String(item.igdb_id) : '—';
+            row.appendChild(igdbCell);
+
+            const igdbUpdatedCell = document.createElement('td');
+            igdbUpdatedCell.textContent = formatDate(item.igdb_updated_at);
+            row.appendChild(igdbUpdatedCell);
+
+            const localEditedCell = document.createElement('td');
+            localEditedCell.textContent = formatDate(item.local_last_edited_at);
+            row.appendChild(localEditedCell);
+
+            const actionsCell = document.createElement('td');
+            actionsCell.className = 'actions-cell';
+            const editLink = document.createElement('a');
+            editLink.href = buildEditUrl(item.processed_game_id);
+            editLink.className = 'icon-button';
+            editLink.title = 'Edit game';
+            editLink.appendChild(createIcon('edit', 'material-symbols-rounded'));
+            const editLabel = document.createElement('span');
+            editLabel.className = 'sr-only';
+            editLabel.textContent = `Edit ${item.name || 'game'}`;
+            editLink.appendChild(editLabel);
+            actionsCell.appendChild(editLink);
+
+            const viewButton = document.createElement('button');
+            viewButton.type = 'button';
+            viewButton.className = 'icon-button';
+            viewButton.title = 'View changes';
+            viewButton.dataset.updateId = String(item.processed_game_id);
+            viewButton.appendChild(createIcon('difference', 'material-symbols-rounded'));
+            const viewLabel = document.createElement('span');
+            viewLabel.className = 'sr-only';
+            viewLabel.textContent = `View changes for ${item.name || 'game'}`;
+            viewButton.appendChild(viewLabel);
+            viewButton.addEventListener('click', () => openDiffModal(item.processed_game_id));
+            actionsCell.appendChild(viewButton);
+
+            row.appendChild(actionsCell);
+            fragment.appendChild(row);
+        });
+        elements.tableBody.appendChild(fragment);
+    }
+
+    function updateSortIndicators() {
+        elements.sortButtons.forEach((button) => {
+            const key = button.dataset.sort;
+            const indicator = button.querySelector('.sort-indicator');
+            const header = button.closest('th');
+            if (state.sortKey === key) {
+                button.classList.add('is-active');
+                if (indicator) {
+                    indicator.textContent = state.sortDir === 'asc' ? 'arrow_upward' : 'arrow_downward';
+                }
+                if (header) {
+                    header.setAttribute('aria-sort', state.sortDir === 'asc' ? 'ascending' : 'descending');
+                }
+            } else {
+                button.classList.remove('is-active');
+                if (indicator) {
+                    indicator.textContent = 'unfold_more';
+                }
+                if (header) {
+                    header.setAttribute('aria-sort', 'none');
+                }
+            }
+        });
+    }
+
+    function handleSort(event) {
+        const button = event.currentTarget;
+        if (!button) {
+            return;
+        }
+        const key = button.dataset.sort;
+        if (!key) {
+            return;
+        }
+        if (state.sortKey === key) {
+            state.sortDir = state.sortDir === 'asc' ? 'desc' : 'asc';
+        } else {
+            state.sortKey = key;
+            state.sortDir = key === 'name' ? 'asc' : 'desc';
+        }
+        updateSortIndicators();
+        applyFilters();
+    }
+
+    function attachSortHandlers() {
+        elements.sortButtons.forEach((button) => {
+            button.addEventListener('click', handleSort);
+        });
+    }
+
+    function updateSearchTerm(event) {
+        state.searchTerm = event.target.value || '';
+        applyFilters();
+    }
+
+    function setRefreshButtonLoading(loading) {
+        const button = elements.refreshButton;
+        if (!button) {
+            return;
+        }
+        const label = button.querySelector('.btn-label');
+        if (loading) {
+            button.disabled = true;
+            if (label) {
+                button.dataset.originalLabel = label.textContent;
+                label.textContent = 'Updating…';
+            }
+        } else {
+            button.disabled = false;
+            if (label && button.dataset.originalLabel) {
+                label.textContent = button.dataset.originalLabel;
+            }
+        }
+    }
+
+    function buildDetailUrl(id) {
+        if (config.detailUrlTemplate) {
+            return config.detailUrlTemplate.replace('{id}', encodeURIComponent(id));
+        }
+        return `/api/updates/${encodeURIComponent(id)}`;
+    }
+
+    async function fetchDiffDetail(id) {
+        if (state.detailCache.has(id)) {
+            return state.detailCache.get(id);
+        }
+        const response = await fetch(buildDetailUrl(id));
+        let payload = null;
+        try {
+            payload = await response.json();
+        } catch (err) {
+            payload = null;
+        }
+        if (!response.ok || !payload || payload.error) {
+            const errorMessage = payload && payload.error ? payload.error : 'Failed to load update details.';
+            throw new Error(errorMessage);
+        }
+        state.detailCache.set(id, payload);
+        return payload;
+    }
+
+    function showModalShell() {
+        if (!modal.backdrop) {
+            return;
+        }
+        lastFocusedElement = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+        modal.backdrop.hidden = false;
+        modal.backdrop.classList.remove('hidden');
+        document.body.classList.add('modal-open');
+        if (modal.closeButton) {
+            modal.closeButton.focus();
+        }
+    }
+
+    function closeModal() {
+        if (!modal.backdrop) {
+            return;
+        }
+        modal.backdrop.classList.add('hidden');
+        modal.backdrop.hidden = true;
+        document.body.classList.remove('modal-open');
+        if (modal.diffList) {
+            modal.diffList.innerHTML = '';
+        }
+        if (modal.empty) {
+            modal.empty.textContent = modalEmptyDefaultText;
+            modal.empty.hidden = true;
+        }
+        if (modal.subtitle) {
+            modal.subtitle.textContent = '';
+        }
+        if (lastFocusedElement && document.body.contains(lastFocusedElement)) {
+            lastFocusedElement.focus();
+        }
+        lastFocusedElement = null;
+    }
+
+    function setMetaValue(element, value) {
+        if (!element) {
+            return;
+        }
+        element.textContent = value ? String(value) : '—';
+    }
+
+    function renderDiff(diff) {
+        if (!modal.diffList || !modal.empty) {
+            return;
+        }
+        modal.diffList.innerHTML = '';
+        modal.empty.textContent = modalEmptyDefaultText;
+        const entries = Object.entries(diff || {});
+        if (!entries.length) {
+            modal.empty.hidden = false;
+            return;
+        }
+        modal.empty.hidden = true;
+        entries.sort((a, b) => a[0].localeCompare(b[0]));
+        const fragment = document.createDocumentFragment();
+        entries.forEach(([field, payload]) => {
+            const section = document.createElement('section');
+            section.className = 'diff-field';
+            const heading = document.createElement('h3');
+            heading.textContent = field;
+            section.appendChild(heading);
+            const columns = document.createElement('div');
+            columns.className = 'diff-columns';
+            columns.appendChild(buildDiffColumn('IGDB', payload.added, 'diff-added'));
+            columns.appendChild(buildDiffColumn('Local', payload.removed, 'diff-removed'));
+            section.appendChild(columns);
+            fragment.appendChild(section);
+        });
+        modal.diffList.appendChild(fragment);
+    }
+
+    function buildDiffColumn(label, value, modifier) {
+        const column = document.createElement('div');
+        column.className = 'diff-column';
+        const title = document.createElement('h4');
+        title.textContent = label;
+        column.appendChild(title);
+        if (Array.isArray(value) && value.length) {
+            const list = document.createElement('ul');
+            list.className = 'diff-pills';
+            value.forEach((item) => {
+                const pill = document.createElement('li');
+                pill.className = `diff-pill ${modifier}`;
+                pill.textContent = item;
+                list.appendChild(pill);
+            });
+            column.appendChild(list);
+        } else if (value) {
+            const paragraph = document.createElement('p');
+            paragraph.className = `diff-value ${modifier}`;
+            paragraph.textContent = value;
+            column.appendChild(paragraph);
+        } else {
+            const empty = document.createElement('p');
+            empty.className = 'diff-value diff-empty';
+            empty.textContent = '—';
+            column.appendChild(empty);
+        }
+        return column;
+    }
+
+    async function openDiffModal(id) {
+        const update = state.updateMap.get(id);
+        if (!update) {
+            showToast('Unable to find update details for that game.', 'warning');
+            return;
+        }
+        showModalShell();
+        if (modal.empty) {
+            modal.empty.textContent = 'Loading changes…';
+            modal.empty.hidden = false;
+        }
+        if (modal.diffList) {
+            modal.diffList.innerHTML = '';
+        }
+        setMetaValue(modal.gameId, update.processed_game_id);
+        setMetaValue(modal.igdbId, update.igdb_id);
+        setMetaValue(modal.igdbUpdated, formatDate(update.igdb_updated_at));
+        setMetaValue(modal.localEdited, formatDate(update.local_last_edited_at));
+        if (modal.subtitle) {
+            modal.subtitle.textContent = update.name ? `IGDB diff for ${update.name}` : '';
+        }
+        try {
+            const detail = await fetchDiffDetail(id);
+            setMetaValue(modal.gameId, detail.processed_game_id);
+            setMetaValue(modal.igdbId, detail.igdb_id);
+            setMetaValue(modal.igdbUpdated, formatDate(detail.igdb_updated_at));
+            setMetaValue(modal.localEdited, formatDate(detail.local_last_edited_at));
+            if (modal.subtitle) {
+                const refreshed = formatDate(detail.refreshed_at);
+                modal.subtitle.textContent = detail.name
+                    ? `${detail.name} • Refreshed ${refreshed}`
+                    : `Refreshed ${refreshed}`;
+            }
+            renderDiff(detail.diff);
+        } catch (error) {
+            console.error(error);
+            if (modal.empty) {
+                modal.empty.textContent = 'Failed to load changes for this update.';
+                modal.empty.hidden = false;
+            }
+            showToast(error.message, 'warning');
+        }
+    }
+
+    async function handleRefresh() {
+        if (!config.refreshUrl) {
+            await loadUpdates();
+            return;
+        }
+        setRefreshButtonLoading(true);
+        try {
+            const response = await fetch(config.refreshUrl, {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+            });
+            let payload = null;
+            try {
+                payload = await response.json();
+            } catch (err) {
+                payload = null;
+            }
+            if (!response.ok || !payload || payload.error) {
+                const errorMessage = payload && payload.error ? payload.error : 'Failed to refresh updates.';
+                throw new Error(errorMessage);
+            }
+            state.detailCache.clear();
+            const updated = Number(payload.updated) || 0;
+            const missingCount = Array.isArray(payload.missing) ? payload.missing.length : 0;
+            let statusMessage = `Fetched ${updated} update${updated === 1 ? '' : 's'}.`;
+            if (missingCount) {
+                statusMessage += ` ${missingCount} IGDB record${missingCount === 1 ? '' : 's'} missing.`;
+            }
+            if (elements.statusLabel) {
+                elements.statusLabel.textContent = statusMessage;
+            }
+            showToast(statusMessage, 'success');
+            await loadUpdates();
+        } catch (error) {
+            console.error(error);
+            showToast(error.message, 'warning');
+        } finally {
+            setRefreshButtonLoading(false);
+        }
+    }
+
+    async function loadUpdates() {
+        setLoading(true);
+        try {
+            const response = await fetch(config.updatesUrl || '/api/updates');
+            let payload = null;
+            try {
+                payload = await response.json();
+            } catch (err) {
+                payload = null;
+            }
+            if (!response.ok || !payload || !Array.isArray(payload.updates)) {
+                throw new Error(payload && payload.error ? payload.error : 'Failed to load updates.');
+            }
+            state.updates = payload.updates;
+            state.updateMap = new Map(state.updates.map((item) => [item.processed_game_id, item]));
+            applyFilters();
+            updateSortIndicators();
+        } catch (error) {
+            console.error(error);
+            showToast(error.message, 'warning');
+            state.updates = [];
+            state.filtered = [];
+            if (elements.tableBody) {
+                elements.tableBody.innerHTML = '';
+            }
+            if (elements.emptyState) {
+                elements.emptyState.hidden = false;
+            }
+            updateCount();
+            updateStatusMessage();
+        } finally {
+            setLoading(false);
+        }
+    }
+
+    function bindEvents() {
+        if (elements.searchInput) {
+            elements.searchInput.addEventListener('input', updateSearchTerm);
+        }
+        if (elements.refreshButton) {
+            elements.refreshButton.addEventListener('click', handleRefresh);
+        }
+        if (modal.closeButton) {
+            modal.closeButton.addEventListener('click', closeModal);
+        }
+        if (modal.backdrop) {
+            modal.backdrop.addEventListener('click', (event) => {
+                if (event.target === modal.backdrop) {
+                    closeModal();
+                }
+            });
+        }
+        document.addEventListener('keydown', (event) => {
+            if (event.key === 'Escape' && modal.backdrop && !modal.backdrop.hidden) {
+                event.preventDefault();
+                closeModal();
+            }
+        });
+        attachSortHandlers();
+    }
+
+    bindEvents();
+    loadUpdates();
+})();

--- a/templates/index.html
+++ b/templates/index.html
@@ -12,8 +12,17 @@
     <script src="https://cdn.jsdelivr.net/npm/cropperjs@1.5.13/dist/cropper.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/choices.js/public/assets/scripts/choices.min.js"></script>
 </head>
-<body>
+<body class="page-editor">
     <div id="toast" role="status" aria-live="polite"></div>
+    <header class="app-topbar" aria-label="Primary navigation">
+        <div class="topbar-content">
+            <a class="topbar-brand" href="{{ url_for('index') }}">Game Editor</a>
+            <nav class="topbar-nav" aria-label="Global">
+                <a class="topbar-link" href="{{ url_for('updates_page') }}">IGDB Updates</a>
+                <a class="topbar-link" href="{{ url_for('logout') }}">Logout</a>
+            </nav>
+        </div>
+    </header>
     <header class="editor-header">
         <div class="header-main">
             <div class="header-left">

--- a/templates/updates.html
+++ b/templates/updates.html
@@ -4,15 +4,136 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>IGDB Updates</title>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@20..48,400,0,0" />
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}" />
 </head>
-<body>
-    <main class="updates-container">
-        <header>
-            <h1>IGDB Updates</h1>
-            <p>This page uses the updates API to populate data.</p>
+<body class="page-updates">
+    <div id="toast" role="status" aria-live="polite"></div>
+    <header class="app-topbar" aria-label="Primary navigation">
+        <div class="topbar-content">
+            <a class="topbar-brand" href="{{ url_for('index') }}">Game Editor</a>
+            <nav class="topbar-nav" aria-label="Global">
+                <a class="topbar-link is-active" href="{{ url_for('updates_page') }}">IGDB Updates</a>
+                <a class="topbar-link" href="{{ url_for('logout') }}">Logout</a>
+            </nav>
+        </div>
+    </header>
+    <main class="updates-page">
+        <header class="updates-header">
+            <div class="updates-title">
+                <h1>IGDB Updates</h1>
+                <p>Monitor pending changes from IGDB before applying them to the local catalog.</p>
+            </div>
+            <div class="updates-actions">
+                <label class="updates-search" for="updates-search">
+                    <span class="sr-only">Search updates</span>
+                    <span class="material-symbols-rounded" aria-hidden="true">search</span>
+                    <input
+                        type="search"
+                        id="updates-search"
+                        placeholder="Search by game, ID or IGDB ID"
+                        autocomplete="off"
+                        data-search
+                    />
+                </label>
+                <button type="button" class="btn btn-blue" data-refresh>
+                    <span class="btn-icon" aria-hidden="true">
+                        <span class="material-symbols-rounded">refresh</span>
+                    </span>
+                    <span class="btn-label">Update</span>
+                </button>
+            </div>
         </header>
-        <section aria-live="polite" id="updates-root"></section>
+        <section class="updates-summary" aria-live="polite">
+            <span>Total entries:</span>
+            <strong data-count>0</strong>
+            <span class="updates-status" data-refresh-status></span>
+        </section>
+        <section class="updates-table-card">
+            <div class="table-scroll" role="region" aria-live="polite" aria-label="Updates table">
+                <table class="updates-table">
+                    <thead>
+                        <tr>
+                            <th scope="col" data-sortable aria-sort="descending">
+                                <button type="button" class="sort-button" data-sort="refreshed_at">
+                                    <span>Refreshed</span>
+                                    <span class="sort-indicator material-symbols-rounded" aria-hidden="true">arrow_downward</span>
+                                </button>
+                            </th>
+                            <th scope="col" data-sortable aria-sort="none">
+                                <button type="button" class="sort-button" data-sort="name">
+                                    <span>Game</span>
+                                    <span class="sort-indicator material-symbols-rounded" aria-hidden="true">unfold_more</span>
+                                </button>
+                            </th>
+                            <th scope="col" data-sortable aria-sort="none">
+                                <button type="button" class="sort-button" data-sort="processed_game_id">
+                                    <span>Game ID</span>
+                                    <span class="sort-indicator material-symbols-rounded" aria-hidden="true">unfold_more</span>
+                                </button>
+                            </th>
+                            <th scope="col">IGDB ID</th>
+                            <th scope="col">IGDB Updated</th>
+                            <th scope="col">Local Edited</th>
+                            <th scope="col" class="actions-column">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody data-updates-body></tbody>
+                </table>
+            </div>
+            <div class="table-empty" data-empty-state hidden>
+                <p>No updates found. Try refreshing or adjust your search.</p>
+            </div>
+            <div class="table-loading" data-loading-state hidden>
+                <span class="material-symbols-rounded" aria-hidden="true">hourglass_empty</span>
+                <p>Loading updates…</p>
+            </div>
+        </section>
     </main>
+    <div class="modal-backdrop hidden" data-modal hidden>
+        <div class="modal-dialog" role="dialog" aria-modal="true" aria-labelledby="diff-modal-title">
+            <header class="modal-header">
+                <div class="modal-titles">
+                    <h2 id="diff-modal-title">Update details</h2>
+                    <p class="modal-subtitle" data-modal-subtitle></p>
+                </div>
+                <button type="button" class="icon-button" data-close-modal aria-label="Close dialog">
+                    <span class="material-symbols-rounded" aria-hidden="true">close</span>
+                </button>
+            </header>
+            <div class="modal-meta">
+                <div class="meta-item">
+                    <span class="meta-label">Game ID</span>
+                    <span class="meta-value" data-modal-game-id></span>
+                </div>
+                <div class="meta-item">
+                    <span class="meta-label">IGDB ID</span>
+                    <span class="meta-value" data-modal-igdb-id></span>
+                </div>
+                <div class="meta-item">
+                    <span class="meta-label">IGDB Updated</span>
+                    <span class="meta-value" data-modal-igdb-updated></span>
+                </div>
+                <div class="meta-item">
+                    <span class="meta-label">Local Edited</span>
+                    <span class="meta-value" data-modal-local-edited></span>
+                </div>
+            </div>
+            <div class="modal-body" data-modal-body>
+                <p class="modal-empty" data-modal-empty hidden>No differences were recorded for this game.</p>
+                <div class="diff-list" data-diff-list></div>
+            </div>
+        </div>
+    </div>
+    <script>
+        window.updatesConfig = {
+            editBaseUrl: {{ url_for('index')|tojson }},
+            updatesUrl: {{ url_for('api_updates_list')|tojson }},
+            refreshUrl: {{ url_for('api_updates_refresh')|tojson }},
+            detailUrlTemplate: {{ url_for('api_updates_detail', processed_game_id=0)|replace('0', '{id}')|tojson }}
+        };
+    </script>
+    <script src="{{ url_for('static', filename='updates.js') }}" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a polished IGDB updates dashboard with sortable table, search, and modal diff viewer
- wire up dedicated client script to fetch updates, refresh data, and render change details with color cues
- introduce shared top navigation linking editor and updates views along with supporting styles

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d096e85e648333aac2ab8a307aa26d