### PR TITLE
Add IGDB user agent header and unit test

### DIFF
--- a/app.py
+++ b/app.py
@@ -40,6 +40,9 @@ COVERS_DIR = 'covers_out'
 app = Flask(__name__)
 app.secret_key = os.environ.get('APP_SECRET_KEY', 'dev-secret')
 APP_PASSWORD = os.environ.get('APP_PASSWORD', 'password')
+IGDB_USER_AGENT = os.environ.get(
+    'IGDB_USER_AGENT', 'TT-Game-Liste/1.0 (support@example.com)'
+)
 logging.basicConfig(level=logging.DEBUG)
 app.logger.setLevel(logging.DEBUG)
 logger.setLevel(logging.DEBUG)
@@ -410,6 +413,7 @@ def fetch_igdb_metadata(
     request.add_header('Client-ID', client_id)
     request.add_header('Authorization', f'Bearer {access_token}')
     request.add_header('Accept', 'application/json')
+    request.add_header('User-Agent', IGDB_USER_AGENT)
 
     try:
         with urlopen(request) as response:


### PR DESCRIPTION
## Summary
- add a configurable IGDB user agent signature and attach it to outgoing metadata requests
- cover the IGDB metadata helper with a unit test that verifies the custom User-Agent header is applied

## Testing
- pytest tests/test_updates_api.py

------
https://chatgpt.com/codex/tasks/task_e_68d1532f8a688333846e9cc1e68b552b