### PR TITLE
Add IGDB user agent header and test coverage

### DIFF
--- a/app.py
+++ b/app.py
@@ -40,9 +40,8 @@ COVERS_DIR = 'covers_out'
 app = Flask(__name__)
 app.secret_key = os.environ.get('APP_SECRET_KEY', 'dev-secret')
 APP_PASSWORD = os.environ.get('APP_PASSWORD', 'password')
-IGDB_USER_AGENT = os.environ.get(
-    'IGDB_USER_AGENT', 'TT-Game-Liste/1.0 (support@example.com)'
-)
+DEFAULT_IGDB_USER_AGENT = 'TT-Game-Liste/1.0 (support@example.com)'
+IGDB_USER_AGENT = os.environ.get('IGDB_USER_AGENT') or DEFAULT_IGDB_USER_AGENT
 logging.basicConfig(level=logging.DEBUG)
 app.logger.setLevel(logging.DEBUG)
 logger.setLevel(logging.DEBUG)


### PR DESCRIPTION
## Summary
- ensure the IGDB user agent header always defaults to a valid signature when the environment variable is unset
- add a regression test that patches the IGDB request pipeline and asserts the User-Agent header is present

## Testing
- pytest tests/test_updates_api.py

------
https://chatgpt.com/codex/tasks/task_e_68d1679243fc8333b2dee34d85d0905c