### PR TITLE
Expose lookup APIs and update editor lookups

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -137,12 +137,14 @@
                         <label>Category
                             <select id="category"></select>
                         </label>
-                        <label>Developers
-                            <input type="text" id="developers" autocomplete="off" />
-                        </label>
-                        <label>Publishers
-                            <input type="text" id="publishers" autocomplete="off" />
-                        </label>
+                        <div class="chip-field">
+                            <label for="developers">Developers</label>
+                            <select id="developers" multiple aria-label="Developers"></select>
+                        </div>
+                        <div class="chip-field">
+                            <label for="publishers">Publishers</label>
+                            <select id="publishers" multiple aria-label="Publishers"></select>
+                        </div>
                     </div>
                 </details>
             </form>
@@ -164,7 +166,6 @@
     </main>
     <script>
         window.categoriesList = {{ categories|tojson }};
-        window.platformsList = {{ platforms|tojson }};
     </script>
     <script src="{{ url_for('static', filename='main.js') }}"></script>
 </body>


### PR DESCRIPTION
## Summary
- add a reusable `/api/lookups/<type>` endpoint that returns normalized lookup options from the database
- load lookup data on the editor, initialize Choices.js multi-selects, and persist selections by lookup ID in the save payload
- replace the developers and publishers text boxes with multi-select controls in the editor template

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1bedce2bc8333a827923ec1e8d050