### PR TITLE
Store lookup IDs inline on processed games

### DIFF
--- a/tests/test_api_game_by_id.py
+++ b/tests/test_api_game_by_id.py
@@ -1,3 +1,4 @@
+import json
 import os
 import uuid
 import importlib.util
@@ -53,10 +54,6 @@ def test_game_by_id_returns_payload(tmp_path):
     (upload_dir / temp_name).write_text("temp")
     with app_module.db_lock:
         with app_module.db:
-            app_module.db.execute(
-                'INSERT INTO processed_games ("ID", "Source Index", "Name") VALUES (?, ?, ?)',
-                (1, '0', 'Catalogued Game'),
-            )
             dev_id = app_module.db.execute(
                 'INSERT INTO developers (name) VALUES (?)',
                 ('Catalogued Dev',),
@@ -66,12 +63,19 @@ def test_game_by_id_returns_payload(tmp_path):
                 ('Adventure',),
             ).lastrowid
             app_module.db.execute(
-                'INSERT INTO processed_game_developers (processed_game_id, developer_id) VALUES (?, ?)',
-                (1, dev_id),
-            )
-            app_module.db.execute(
-                'INSERT INTO processed_game_genres (processed_game_id, genre_id) VALUES (?, ?)',
-                (1, genre_id),
+                'INSERT INTO processed_games ('
+                '"ID", "Source Index", "Name", "Developers", "Genres", '
+                'developers_ids, genres_ids'
+                ') VALUES (?, ?, ?, ?, ?, ?, ?)',
+                (
+                    1,
+                    '0',
+                    'Catalogued Game',
+                    'Catalogued Dev',
+                    'Adventure',
+                    json.dumps([dev_id]),
+                    json.dumps([genre_id]),
+                ),
             )
     app_module.navigator.current_index = 1
     client = app_module.app.test_client()

--- a/tests/test_lookup_tables.py
+++ b/tests/test_lookup_tables.py
@@ -1,6 +1,7 @@
 import os
 import sqlite3
 import uuid
+import json
 import importlib.util
 from pathlib import Path
 
@@ -105,53 +106,50 @@ def test_lookup_tables_backfilled(tmp_path):
 
         platform_rows = app.db.execute('SELECT name FROM platforms').fetchall()
         assert {row['name'] for row in platform_rows} == {"PC"}
-
-        developer_link = app.db.execute(
-            'SELECT processed_game_id, developer_id FROM processed_game_developers'
+        processed_row = app.db.execute(
+            '''SELECT developers_ids, publishers_ids, genres_ids,
+                      game_modes_ids, platforms_ids
+               FROM processed_games WHERE "ID"=?''',
+            (1,),
         ).fetchone()
-        assert developer_link['processed_game_id'] == 1
+        assert processed_row is not None
+
+        developer_ids = json.loads(processed_row['developers_ids'])
+        assert developer_ids
         developer_name = app.db.execute(
             'SELECT name FROM developers WHERE id=?',
-            (developer_link['developer_id'],),
+            (developer_ids[0],),
         ).fetchone()
         assert developer_name['name'] == "Foo Studio"
 
-        publisher_link = app.db.execute(
-            'SELECT processed_game_id, publisher_id FROM processed_game_publishers'
-        ).fetchone()
-        assert publisher_link['processed_game_id'] == 1
+        publisher_ids = json.loads(processed_row['publishers_ids'])
+        assert publisher_ids
         publisher_name = app.db.execute(
             'SELECT name FROM publishers WHERE id=?',
-            (publisher_link['publisher_id'],),
+            (publisher_ids[0],),
         ).fetchone()
         assert publisher_name['name'] == "Bar Publishing"
 
-        genre_link = app.db.execute(
-            'SELECT processed_game_id, genre_id FROM processed_game_genres'
-        ).fetchone()
-        assert genre_link['processed_game_id'] == 1
+        genre_ids = json.loads(processed_row['genres_ids'])
+        assert genre_ids
         genre_name = app.db.execute(
             'SELECT name FROM genres WHERE id=?',
-            (genre_link['genre_id'],),
+            (genre_ids[0],),
         ).fetchone()
         assert genre_name['name'] == "Action"
 
-        mode_link = app.db.execute(
-            'SELECT processed_game_id, game_mode_id FROM processed_game_game_modes'
-        ).fetchone()
-        assert mode_link['processed_game_id'] == 1
+        mode_ids = json.loads(processed_row['game_modes_ids'])
+        assert mode_ids
         mode_name = app.db.execute(
             'SELECT name FROM game_modes WHERE id=?',
-            (mode_link['game_mode_id'],),
+            (mode_ids[0],),
         ).fetchone()
         assert mode_name['name'] == "Single-player"
 
-        platform_link = app.db.execute(
-            'SELECT processed_game_id, platform_id FROM processed_game_platforms'
-        ).fetchone()
-        assert platform_link['processed_game_id'] == 1
+        platform_ids = json.loads(processed_row['platforms_ids'])
+        assert platform_ids
         platform_name = app.db.execute(
             'SELECT name FROM platforms WHERE id=?',
-            (platform_link['platform_id'],),
+            (platform_ids[0],),
         ).fetchone()
         assert platform_name['name'] == "PC"


### PR DESCRIPTION
## Summary
- add JSON-based lookup ID columns on processed_games and adjust migrations/backfill helpers to populate them instead of join tables
- update lookup fetch/save logic (including IGDB collectors) to read/write the inline ID lists
- refresh API tests to seed and assert the new lookup storage format

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1c5ab04848333a9011c3151fb67c1