### PR TITLE
Store lookup relations in join tables

### DIFF
--- a/tests/test_api_game_by_id.py
+++ b/tests/test_api_game_by_id.py
@@ -1,4 +1,3 @@
-import json
 import os
 import uuid
 import importlib.util
@@ -64,18 +63,25 @@ def test_game_by_id_returns_payload(tmp_path):
             ).lastrowid
             app_module.db.execute(
                 'INSERT INTO processed_games ('
-                '"ID", "Source Index", "Name", "Developers", "Genres", '
-                'developers_ids, genres_ids'
-                ') VALUES (?, ?, ?, ?, ?, ?, ?)',
+                '"ID", "Source Index", "Name", "Developers", "Genres"'
+                ') VALUES (?, ?, ?, ?, ?)',
                 (
                     1,
                     '0',
                     'Catalogued Game',
                     'Catalogued Dev',
                     'Adventure',
-                    json.dumps([dev_id]),
-                    json.dumps([genre_id]),
                 ),
+            )
+            app_module.db.execute(
+                'INSERT INTO processed_game_developers (processed_game_id, developer_id) '
+                'VALUES (?, ?)',
+                (1, dev_id),
+            )
+            app_module.db.execute(
+                'INSERT INTO processed_game_genres (processed_game_id, genre_id) '
+                'VALUES (?, ?)',
+                (1, genre_id),
             )
     app_module.navigator.current_index = 1
     client = app_module.app.test_client()

--- a/tests/test_api_save.py
+++ b/tests/test_api_save.py
@@ -1,4 +1,3 @@
-import json
 import os
 import uuid
 import importlib.util
@@ -94,7 +93,7 @@ def test_api_save_success_increments_seq(tmp_path):
     assert app.navigator.seq_index == 2
     with app.db_lock:
         cur = app.db.execute(
-            'SELECT "ID", "igdb_id", "Developers", "Genres", developers_ids, genres_ids '
+            'SELECT "ID", "igdb_id", "Developers", "Genres" '
             'FROM processed_games WHERE "Source Index"=?',
             ('0',),
         )
@@ -103,19 +102,19 @@ def test_api_save_success_increments_seq(tmp_path):
     assert row['igdb_id'] == '4321'
     assert row['Developers'] == 'Dev Studio'
     assert row['Genres'] == 'Action'
-    developer_ids = json.loads(row['developers_ids'])
-    assert developer_ids
-    genre_ids = json.loads(row['genres_ids'])
-    assert genre_ids
     with app.db_lock:
         developer_row = app.db.execute(
-            'SELECT name FROM developers WHERE id=?',
-            (developer_ids[0],),
+            'SELECT d.name FROM processed_game_developers pgd '
+            'JOIN developers d ON d.id = pgd.developer_id '
+            'WHERE pgd.processed_game_id=?',
+            (row['ID'],),
         ).fetchone()
         assert developer_row['name'] == 'Dev Studio'
         genre_row = app.db.execute(
-            'SELECT name FROM genres WHERE id=?',
-            (genre_ids[0],),
+            'SELECT g.name FROM processed_game_genres pgg '
+            'JOIN genres g ON g.id = pgg.genre_id '
+            'WHERE pgg.processed_game_id=?',
+            (row['ID'],),
         ).fetchone()
         assert genre_row['name'] == 'Action'
 


### PR DESCRIPTION
## Summary
- migrate existing processed game lookup data into dedicated join tables and remove legacy JSON *_ids columns
- update lookup fetching, resolution, and save flows to read/write the new join tables while keeping multiselect behavior intact
- adjust tests to assert against join tables and ensure migrations drop the deprecated columns

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1d0897a6c83338ff495f07ceac1f3