### PR TITLE
Protect processed summaries from automated updates

### DIFF
--- a/scripts/resync_db.py
+++ b/scripts/resync_db.py
@@ -10,6 +10,7 @@ from app import (
     db_lock,
     extract_igdb_id,
     coerce_igdb_id,
+    has_summary_text,
 )
 
 
@@ -50,7 +51,7 @@ def main() -> None:
         with conn:
             for src_index, igdb_id in sources:
                 cur = conn.execute(
-                    'SELECT "igdb_id" FROM processed_games WHERE "Source Index"=?',
+                    'SELECT "igdb_id", "Summary" FROM processed_games WHERE "Source Index"=?',
                     (src_index,),
                 )
                 row = cur.fetchone()
@@ -62,6 +63,13 @@ def main() -> None:
                     continue
 
                 if not igdb_id:
+                    continue
+
+                try:
+                    summary_value = row['Summary']
+                except (KeyError, IndexError, TypeError):
+                    summary_value = None
+                if has_summary_text(summary_value):
                     continue
 
                 existing_id = _normalize_existing_id(row)

--- a/tests/test_backfill_igdb_ids.py
+++ b/tests/test_backfill_igdb_ids.py
@@ -1,0 +1,40 @@
+import pandas as pd
+
+from tests.app_helpers import load_app
+
+
+def test_backfill_igdb_ids_skips_rows_with_summary(tmp_path):
+    app_module = load_app(tmp_path)
+
+    with app_module.db_lock:
+        with app_module.db:
+            app_module.db.execute('DELETE FROM processed_games')
+            app_module.db.executemany(
+                'INSERT INTO processed_games ("ID", "Source Index", "Name", "Summary") VALUES (?, ?, ?, ?)',
+                [
+                    (1, '0', 'First Game', ''),
+                    (2, '1', 'Second Game', 'Existing summary'),
+                ],
+            )
+
+    app_module.games_df = pd.DataFrame(
+        [
+            {'Source Index': '0', 'id': 101},
+            {'Source Index': '1', 'id': 202},
+        ]
+    )
+    app_module.total_games = len(app_module.games_df)
+    if hasattr(app_module, 'reset_source_index_cache'):
+        app_module.reset_source_index_cache()
+
+    app_module.backfill_igdb_ids()
+
+    with app_module.db_lock:
+        rows = app_module.db.execute(
+            'SELECT "Source Index", "igdb_id" FROM processed_games ORDER BY "Source Index"'
+        ).fetchall()
+
+    assert rows[0]['Source Index'] == '0'
+    assert rows[0]['igdb_id'] == '101'
+    assert rows[1]['Source Index'] == '1'
+    assert rows[1]['igdb_id'] is None


### PR DESCRIPTION
## Summary
- add a helper to detect non-empty summaries and reuse it when seeding or backfilling processed games
- prevent automated seed/backfill/resync flows from touching rows with existing summaries
- cover the new behavior with tests for seeding and IGDB backfill

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3629fa464833386692034fa09fd41