### PR TITLE
Require summary and cover to mark games as done

### DIFF
--- a/scripts/resync_db.py
+++ b/scripts/resync_db.py
@@ -10,7 +10,7 @@ from app import (
     db_lock,
     extract_igdb_id,
     coerce_igdb_id,
-    has_summary_text,
+    is_processed_game_done,
 )
 
 
@@ -51,7 +51,8 @@ def main() -> None:
         with conn:
             for src_index, igdb_id in sources:
                 cur = conn.execute(
-                    'SELECT "igdb_id", "Summary" FROM processed_games WHERE "Source Index"=?',
+                    'SELECT "igdb_id", "Summary", "Cover Path" '
+                    'FROM processed_games WHERE "Source Index"=?',
                     (src_index,),
                 )
                 row = cur.fetchone()
@@ -69,7 +70,11 @@ def main() -> None:
                     summary_value = row['Summary']
                 except (KeyError, IndexError, TypeError):
                     summary_value = None
-                if has_summary_text(summary_value):
+                try:
+                    cover_value = row['Cover Path']
+                except (KeyError, IndexError, TypeError):
+                    cover_value = None
+                if is_processed_game_done(summary_value, cover_value):
                     continue
 
                 existing_id = _normalize_existing_id(row)

--- a/tests/test_backfill_igdb_ids.py
+++ b/tests/test_backfill_igdb_ids.py
@@ -10,10 +10,11 @@ def test_backfill_igdb_ids_skips_rows_with_summary(tmp_path):
         with app_module.db:
             app_module.db.execute('DELETE FROM processed_games')
             app_module.db.executemany(
-                'INSERT INTO processed_games ("ID", "Source Index", "Name", "Summary") VALUES (?, ?, ?, ?)',
+                'INSERT INTO processed_games ("ID", "Source Index", "Name", "Summary", "Cover Path") '
+                'VALUES (?, ?, ?, ?, ?)',
                 [
-                    (1, '0', 'First Game', ''),
-                    (2, '1', 'Second Game', 'Existing summary'),
+                    (1, '0', 'First Game', '', None),
+                    (2, '1', 'Second Game', 'Existing summary', f"{app_module.PROCESSED_DIR}/2.jpg"),
                 ],
             )
 

--- a/tests/test_navigator_state.py
+++ b/tests/test_navigator_state.py
@@ -9,8 +9,9 @@ def populate_db(app_module, count):
         with app_module.db:
             for i in range(count):
                 app_module.db.execute(
-                    'INSERT INTO processed_games ("ID", "Source Index") VALUES (?, ?)',
-                    (i, str(i)),
+                    'INSERT INTO processed_games ("ID", "Source Index", "Summary", "Cover Path") '
+                    'VALUES (?, ?, ?, ?)',
+                    (i, str(i), f'Summary {i}', f'{app_module.PROCESSED_DIR}/{i}.jpg'),
                 )
 
 

--- a/tests/test_seed_processed_games.py
+++ b/tests/test_seed_processed_games.py
@@ -46,8 +46,15 @@ def test_seed_processed_games_skips_rows_with_summary(tmp_path):
         with app_module.db:
             app_module.db.execute('DELETE FROM processed_games')
             app_module.db.execute(
-                'INSERT INTO processed_games ("ID", "Source Index", "Name", "Summary") VALUES (?, ?, ?, ?)',
-                (5, ' 00123 ', 'Stored Name', 'Manual summary'),
+                'INSERT INTO processed_games ("ID", "Source Index", "Name", "Summary", "Cover Path") '
+                'VALUES (?, ?, ?, ?, ?)',
+                (
+                    5,
+                    ' 00123 ',
+                    'Stored Name',
+                    'Manual summary',
+                    f"{app_module.PROCESSED_DIR}/5.jpg",
+                ),
             )
 
     app_module.games_df = pd.DataFrame([


### PR DESCRIPTION
## Summary
- add helpers to treat processed games as complete only when both a summary and cover path exist, updating navigator, seeding, and maintenance utilities accordingly
- adjust the save endpoint to preserve existing cover metadata, reuse the new completion rule, and keep processed counters in sync
- refresh tests to seed cover paths and provide images so progress tracking reflects the updated definition of "Done"

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d36b1cb8448333bc0c3d9c3f608c20