### PR TITLE
Add script to refresh processed names from IGDB

### DIFF
--- a/scripts/rename_names_from_igdb.py
+++ b/scripts/rename_names_from_igdb.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Rename processed game rows using the live IGDB catalogue."""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+from typing import Any, Callable, Iterable, Mapping
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from app import (
+    coerce_igdb_id,
+    db_lock,
+    exchange_twitch_credentials,
+    fetch_igdb_metadata,
+    get_db,
+)
+
+
+def _normalize_text(value: Any) -> str:
+    """Return a stripped string representation for comparison and storage."""
+
+    if value is None:
+        return ""
+    text = str(value).strip()
+    if text.lower() == "nan":
+        return ""
+    return text
+
+
+def _load_processed_rows(conn: sqlite3.Connection) -> list[sqlite3.Row]:
+    """Load all processed game rows with their identifiers and names."""
+
+    with db_lock:
+        cursor = conn.execute(
+            'SELECT "ID", "Source Index", "igdb_id", "Name" FROM processed_games '
+            'ORDER BY "ID"'
+        )
+        return cursor.fetchall()
+
+
+def rename_processed_games_from_igdb(
+    *,
+    conn: sqlite3.Connection | None = None,
+    exchange_credentials: Callable[[], tuple[str, str]] | None = None,
+    metadata_loader: Callable[[str, str, Iterable[str]], Mapping[str, Mapping[str, Any]]] | None = None,
+) -> dict[str, Any]:
+    """Update the ``Name`` column for each processed game using IGDB data."""
+
+    if exchange_credentials is None:
+        exchange_credentials = exchange_twitch_credentials
+    if metadata_loader is None:
+        metadata_loader = fetch_igdb_metadata
+
+    owns_connection = False
+    if conn is None:
+        conn = get_db()
+        owns_connection = True
+
+    try:
+        rows = _load_processed_rows(conn)
+        total_rows = len(rows)
+        rows_with_igdb_id: list[dict[str, Any]] = []
+        seen_ids: set[str] = set()
+        unique_ids: list[str] = []
+        missing_id_count = 0
+
+        for row in rows:
+            raw_igdb = row["igdb_id"]
+            igdb_id = coerce_igdb_id(raw_igdb)
+            normalized_name = _normalize_text(row["Name"])
+            source_index = _normalize_text(row["Source Index"])
+            entry = {
+                "db_id": row["ID"],
+                "source_index": source_index,
+                "igdb_id": igdb_id,
+                "current_name": normalized_name,
+            }
+            if igdb_id:
+                rows_with_igdb_id.append(entry)
+                if igdb_id not in seen_ids:
+                    seen_ids.add(igdb_id)
+                    unique_ids.append(igdb_id)
+            else:
+                missing_id_count += 1
+
+        if not rows_with_igdb_id:
+            return {
+                "total_rows": total_rows,
+                "rows_with_igdb_id": 0,
+                "missing_id": missing_id_count,
+                "renamed_rows": [],
+                "missing_remote": [],
+                "missing_name": [],
+                "unchanged": 0,
+                "updated": 0,
+            }
+
+        access_token, client_id = exchange_credentials()
+        metadata = metadata_loader(access_token, client_id, unique_ids) or {}
+
+        renamed_rows: list[dict[str, Any]] = []
+        missing_remote_ids: set[str] = set()
+        missing_name_ids: set[str] = set()
+        unchanged_count = 0
+
+        for entry in rows_with_igdb_id:
+            igdb_id = entry["igdb_id"]
+            payload = metadata.get(igdb_id)
+            if not isinstance(payload, Mapping):
+                missing_remote_ids.add(igdb_id)
+                continue
+            remote_name = _normalize_text(payload.get("name"))
+            if not remote_name:
+                missing_name_ids.add(igdb_id)
+                continue
+            if remote_name == entry["current_name"]:
+                unchanged_count += 1
+                continue
+            db_id = entry["db_id"]
+            if db_id is None:
+                missing_remote_ids.add(igdb_id)
+                continue
+            renamed_rows.append(
+                {
+                    "id": db_id,
+                    "source_index": entry["source_index"],
+                    "igdb_id": igdb_id,
+                    "old_name": entry["current_name"],
+                    "new_name": remote_name,
+                }
+            )
+
+        if renamed_rows:
+            updates = [(row["new_name"], row["id"]) for row in renamed_rows]
+            with db_lock:
+                with conn:
+                    conn.executemany(
+                        'UPDATE processed_games SET "Name"=? WHERE "ID"=?', updates
+                    )
+
+        return {
+            "total_rows": total_rows,
+            "rows_with_igdb_id": len(rows_with_igdb_id),
+            "missing_id": missing_id_count,
+            "renamed_rows": renamed_rows,
+            "missing_remote": sorted(missing_remote_ids),
+            "missing_name": sorted(missing_name_ids),
+            "unchanged": unchanged_count,
+            "updated": len(renamed_rows),
+        }
+    finally:
+        if owns_connection and conn is not None:
+            conn.close()
+
+
+def _format_row_label(row: Mapping[str, Any]) -> str:
+    source_index = _normalize_text(row.get("source_index"))
+    if source_index:
+        return f"Source {source_index}"
+    return f"ID {row.get('id')}"
+
+
+def _format_name(value: str) -> str:
+    return value if value else "(empty)"
+
+
+def main() -> None:
+    try:
+        summary = rename_processed_games_from_igdb()
+    except Exception as exc:  # pragma: no cover - surface unexpected failures
+        print(f"Failed to rename processed games: {exc}")
+        raise SystemExit(1)
+
+    renamed_rows = summary["renamed_rows"]
+    if renamed_rows:
+        print("Updated names:")
+        for row in renamed_rows:
+            label = _format_row_label(row)
+            print(
+                f"  {label} (IGDB {row['igdb_id']}): "
+                f"{_format_name(row['old_name'])} -> {_format_name(row['new_name'])}"
+            )
+    else:
+        print("No names required updating.")
+
+    if summary["missing_remote"]:
+        print(
+            "Missing IGDB records for IDs: "
+            + ", ".join(summary["missing_remote"])
+        )
+    if summary["missing_name"]:
+        print(
+            "IGDB responses without names for IDs: "
+            + ", ".join(summary["missing_name"])
+        )
+
+    print(
+        "Processed {total} rows (with IGDB ID: {with_id}, updated: {updated}, "
+        "unchanged: {unchanged}, without IGDB ID: {missing_id}).".format(
+            total=summary["total_rows"],
+            with_id=summary["rows_with_igdb_id"],
+            updated=summary["updated"],
+            unchanged=summary["unchanged"],
+            missing_id=summary["missing_id"],
+        )
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution path
+    main()

--- a/tests/test_rename_names_from_igdb.py
+++ b/tests/test_rename_names_from_igdb.py
@@ -1,0 +1,160 @@
+import importlib
+import sys
+
+from tests.app_helpers import load_app
+
+
+def _load_script(app_module):
+    module_name = "scripts.rename_names_from_igdb"
+    original_app = sys.modules.get("app")
+    sys.modules["app"] = app_module
+    try:
+        if module_name in sys.modules:
+            module = importlib.reload(sys.modules[module_name])
+        else:
+            module = importlib.import_module(module_name)
+    finally:
+        if original_app is None:
+            sys.modules.pop("app", None)
+        else:
+            sys.modules["app"] = original_app
+    return module
+
+
+def test_rename_updates_names_from_igdb(tmp_path):
+    app_module = load_app(tmp_path)
+    script_module = _load_script(app_module)
+
+    with app_module.db_lock:
+        with app_module.db:
+            app_module.db.execute('DELETE FROM processed_games')
+            app_module.db.executemany(
+                'INSERT INTO processed_games ("ID", "Source Index", "Name", "igdb_id") '
+                'VALUES (?, ?, ?, ?)',
+                [
+                    (1, '10', 'Old Name', '100'),
+                    (2, '20', 'Same Name', '200'),
+                    (3, '30', 'Missing Remote', '300'),
+                    (4, '40', 'No ID row', None),
+                ],
+            )
+
+    captured_ids = []
+
+    def fake_exchange():
+        return 'token', 'client'
+
+    def fake_fetch(token, client_id, igdb_ids):
+        captured_ids.extend(list(igdb_ids))
+        assert token == 'token'
+        assert client_id == 'client'
+        return {
+            '100': {'name': 'New Name'},
+            '200': {'name': 'Same Name'},
+        }
+
+    summary = script_module.rename_processed_games_from_igdb(
+        conn=app_module.db,
+        exchange_credentials=fake_exchange,
+        metadata_loader=fake_fetch,
+    )
+
+    assert captured_ids == ['100', '200', '300']
+    assert summary['updated'] == 1
+    assert summary['unchanged'] == 1
+    assert summary['missing_remote'] == ['300']
+    assert summary['missing_name'] == []
+    assert summary['missing_id'] == 1
+    assert summary['rows_with_igdb_id'] == 3
+    assert summary['total_rows'] == 4
+    assert summary['renamed_rows'] == [
+        {
+            'id': 1,
+            'source_index': '10',
+            'igdb_id': '100',
+            'old_name': 'Old Name',
+            'new_name': 'New Name',
+        }
+    ]
+
+    with app_module.db_lock:
+        rows = app_module.db.execute(
+            'SELECT "ID", "Name" FROM processed_games ORDER BY "ID"'
+        ).fetchall()
+
+    assert [row['Name'] for row in rows] == [
+        'New Name',
+        'Same Name',
+        'Missing Remote',
+        'No ID row',
+    ]
+
+
+def test_rename_skips_rows_without_remote_name(tmp_path):
+    app_module = load_app(tmp_path)
+    script_module = _load_script(app_module)
+
+    with app_module.db_lock:
+        with app_module.db:
+            app_module.db.execute('DELETE FROM processed_games')
+            app_module.db.execute(
+                'INSERT INTO processed_games ("ID", "Source Index", "Name", "igdb_id") '
+                'VALUES (?, ?, ?, ?)',
+                (1, '55', 'Keep Original', '555'),
+            )
+
+    def fake_exchange():
+        return 'token', 'client'
+
+    def fake_fetch(token, client_id, igdb_ids):
+        assert list(igdb_ids) == ['555']
+        return {'555': {'name': '   '}}
+
+    summary = script_module.rename_processed_games_from_igdb(
+        conn=app_module.db,
+        exchange_credentials=fake_exchange,
+        metadata_loader=fake_fetch,
+    )
+
+    assert summary['updated'] == 0
+    assert summary['missing_name'] == ['555']
+    assert summary['missing_remote'] == []
+
+    with app_module.db_lock:
+        name = app_module.db.execute(
+            'SELECT "Name" FROM processed_games WHERE "ID"=?',
+            (1,),
+        ).fetchone()['Name']
+
+    assert name == 'Keep Original'
+
+
+def test_rename_without_ids_avoids_api_calls(tmp_path):
+    app_module = load_app(tmp_path)
+    script_module = _load_script(app_module)
+
+    with app_module.db_lock:
+        with app_module.db:
+            app_module.db.execute('DELETE FROM processed_games')
+            app_module.db.execute(
+                'INSERT INTO processed_games ("ID", "Source Index", "Name", "igdb_id") '
+                'VALUES (?, ?, ?, ?)',
+                (1, '77', 'No IGDB', None),
+            )
+
+    def fail_exchange():  # pragma: no cover - should not be called
+        raise AssertionError('exchange_twitch_credentials should not be invoked')
+
+    def fail_fetch(*_args):  # pragma: no cover - should not be called
+        raise AssertionError('fetch_igdb_metadata should not be invoked')
+
+    summary = script_module.rename_processed_games_from_igdb(
+        conn=app_module.db,
+        exchange_credentials=fail_exchange,
+        metadata_loader=fail_fetch,
+    )
+
+    assert summary['total_rows'] == 1
+    assert summary['rows_with_igdb_id'] == 0
+    assert summary['updated'] == 0
+    assert summary['missing_id'] == 1


### PR DESCRIPTION
## Summary
- add a maintenance script that refreshes processed game names using the latest IGDB metadata
- expose CLI output that summarizes renames and missing IGDB data
- cover the new tool with tests to validate updates, skips, and API call handling
- ensure the refresh script inserts the project root into `sys.path` so it can import the `app` module when executed directly

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d36d89b60c8333b306b87496d1e015