### PR TITLE
Add IGDB name correction workflow

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -261,7 +261,8 @@ body.modal-open {
   overflow: hidden;
 }
 
-.progress-bar #progress {
+.progress-bar #progress,
+.progress-bar .progress-fill {
   width: 0;
   height: 100%;
   background: linear-gradient(90deg, var(--color-blue), var(--color-green));
@@ -737,6 +738,23 @@ textarea {
   align-items: center;
   gap: 16px;
   flex-wrap: wrap;
+}
+
+.updates-bulk-action {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.updates-progress {
+  min-width: 0;
+  align-items: flex-start;
+}
+
+.updates-progress .progress-bar {
+  width: 200px;
+  max-width: 100%;
 }
 
 .updates-search {

--- a/templates/updates.html
+++ b/templates/updates.html
@@ -43,6 +43,24 @@
                     </span>
                     <span class="btn-label">Update</span>
                 </button>
+                <div class="updates-bulk-action">
+                    <button type="button" class="btn btn-green" data-fix-names>
+                        <span class="btn-icon" aria-hidden="true">
+                            <span class="material-symbols-rounded">spellcheck</span>
+                        </span>
+                        <span class="btn-label">Fix IGDB Names</span>
+                        <span class="sr-only">Fix processed game names using IGDB data</span>
+                    </button>
+                    <div class="progress-indicator updates-progress" data-fix-progress hidden>
+                        <div class="progress-metrics">
+                            <span class="progress-count" data-fix-count>0/0</span>
+                            <span class="progress-percent" data-fix-percent>0%</span>
+                        </div>
+                        <div class="progress-bar">
+                            <div class="progress-fill" data-fix-bar></div>
+                        </div>
+                    </div>
+                </div>
             </div>
         </header>
         <section class="updates-summary" aria-live="polite">
@@ -136,6 +154,7 @@
             editBaseUrl: {{ url_for('index')|tojson }},
             updatesUrl: {{ url_for('api_updates_list')|tojson }},
             refreshUrl: {{ url_for('api_updates_refresh')|tojson }},
+            fixNamesUrl: {{ url_for('api_updates_fix_names')|tojson }},
             detailUrlTemplate: {{ url_for('api_updates_detail', processed_game_id=0)|replace('0', '{id}')|tojson }}
         };
     </script>


### PR DESCRIPTION
## Summary
- add a Fix IGDB Names action with progress feedback to the updates UI
- implement a batch API endpoint to refresh processed game names from IGDB and update last-edited timestamps
- extend automated tests to cover the new name correction workflow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d37ce382b88333a94f5f9371715de7