### PR TITLE
Add lookup management page and navigation links

### DIFF
--- a/static/lookups.js
+++ b/static/lookups.js
@@ -1,0 +1,551 @@
+(function () {
+    const config = window.lookupsConfig || {};
+    const tables = Array.isArray(config.tables) ? config.tables : [];
+    const labelMap = new Map();
+    const singularMap = new Map();
+
+    tables.forEach((table) => {
+        if (!table || typeof table !== 'object') {
+            return;
+        }
+        const type = typeof table.type === 'string' ? table.type : '';
+        if (!type) {
+            return;
+        }
+        const label = typeof table.label === 'string' ? table.label : type;
+        const singular = typeof table.singular_label === 'string' ? table.singular_label : label;
+        labelMap.set(type, label);
+        singularMap.set(type, singular);
+    });
+
+    let defaultType = typeof config.defaultType === 'string' ? config.defaultType : '';
+    if (!defaultType && tables.length > 0) {
+        const first = tables[0];
+        if (first && typeof first.type === 'string') {
+            defaultType = first.type;
+        }
+    }
+
+    const state = {
+        type: defaultType,
+        items: [],
+        filtered: [],
+        search: '',
+        editingId: null,
+        deletingId: null,
+    };
+
+    const elements = {
+        typeSelect: document.querySelector('[data-type-select]'),
+        searchInput: document.querySelector('[data-search]'),
+        newButton: document.querySelector('[data-new-entry]'),
+        tableBody: document.querySelector('[data-lookup-rows]'),
+        emptyState: document.querySelector('[data-empty-state]'),
+        loadingState: document.querySelector('[data-loading-state]'),
+        countLabel: document.querySelector('[data-entry-count]'),
+        activeLabel: document.querySelector('[data-active-label]'),
+        entryModal: document.querySelector('[data-entry-modal]'),
+        entryModalTitle: document.getElementById('entry-modal-title'),
+        entryModalSubtitle: document.querySelector('[data-entry-modal-subtitle]'),
+        entryForm: document.querySelector('[data-entry-form]'),
+        entryNameInput: document.querySelector('[data-entry-name]'),
+        entrySubmit: document.querySelector('[data-entry-submit]'),
+        entryCancel: document.querySelector('[data-cancel-entry]'),
+        entryClose: document.querySelector('[data-close-entry-modal]'),
+        confirmModal: document.querySelector('[data-confirm-modal]'),
+        confirmSubtitle: document.querySelector('[data-delete-modal-subtitle]'),
+        confirmName: document.querySelector('[data-confirm-name]'),
+        confirmDelete: document.querySelector('[data-confirm-delete]'),
+        confirmCancel: document.querySelector('[data-cancel-delete]'),
+        confirmClose: document.querySelector('[data-close-confirm-modal]'),
+    };
+
+    const toast = document.getElementById('toast');
+    let lastFocusedElement = null;
+
+    function getLabelForType(type) {
+        if (!type) {
+            return '';
+        }
+        return labelMap.get(type) || type;
+    }
+
+    function getSingularLabel(type) {
+        if (!type) {
+            return 'entry';
+        }
+        return singularMap.get(type) || labelMap.get(type) || type;
+    }
+
+    function formatCount(count) {
+        const suffix = count === 1 ? 'entry' : 'entries';
+        return `${count} ${suffix}`;
+    }
+
+    function showToast(message, type = 'success') {
+        if (!toast) {
+            return;
+        }
+        const normalized = type === 'error' ? 'warning' : type;
+        toast.textContent = message;
+        toast.className = '';
+        void toast.offsetWidth;
+        toast.classList.add(normalized, 'show');
+        window.clearTimeout(showToast.timerId);
+        showToast.timerId = window.setTimeout(() => {
+            toast.classList.remove('show');
+        }, 3200);
+    }
+
+    function setActiveLabel() {
+        if (!elements.activeLabel) {
+            return;
+        }
+        elements.activeLabel.textContent = getLabelForType(state.type);
+    }
+
+    function updateCount() {
+        if (!elements.countLabel) {
+            return;
+        }
+        const count = state.filtered.length;
+        elements.countLabel.textContent = formatCount(count);
+    }
+
+    function setLoading(loading) {
+        if (elements.loadingState) {
+            elements.loadingState.hidden = !loading;
+        }
+        if (elements.emptyState && loading) {
+            elements.emptyState.hidden = true;
+        }
+        if (elements.tableBody) {
+            elements.tableBody.setAttribute('aria-busy', loading ? 'true' : 'false');
+        }
+    }
+
+    function applyFilters() {
+        const term = state.search.trim().toLocaleLowerCase();
+        const filtered = term
+            ? state.items.filter((item) => item.name.toLocaleLowerCase().includes(term))
+            : state.items.slice();
+        state.filtered = filtered;
+        updateCount();
+        renderList();
+    }
+
+    function renderList() {
+        if (!elements.tableBody) {
+            return;
+        }
+        elements.tableBody.innerHTML = '';
+        if (!state.filtered.length) {
+            if (elements.emptyState) {
+                elements.emptyState.hidden = false;
+            }
+            return;
+        }
+        if (elements.emptyState) {
+            elements.emptyState.hidden = true;
+        }
+        const fragment = document.createDocumentFragment();
+        state.filtered.forEach((entry) => {
+            const row = document.createElement('tr');
+            row.dataset.entryId = String(entry.id);
+
+            const nameCell = document.createElement('td');
+            const nameText = document.createElement('span');
+            nameText.className = 'lookup-name';
+            nameText.textContent = entry.name;
+            nameCell.appendChild(nameText);
+            row.appendChild(nameCell);
+
+            const actionsCell = document.createElement('td');
+            actionsCell.className = 'actions-cell';
+
+            const editButton = document.createElement('button');
+            editButton.type = 'button';
+            editButton.className = 'icon-button';
+            editButton.dataset.action = 'edit';
+            editButton.dataset.entryId = String(entry.id);
+            editButton.setAttribute('aria-label', `Edit ${entry.name || 'entry'}`);
+            const editIcon = document.createElement('span');
+            editIcon.className = 'material-symbols-rounded';
+            editIcon.textContent = 'edit';
+            editButton.appendChild(editIcon);
+
+            const deleteButton = document.createElement('button');
+            deleteButton.type = 'button';
+            deleteButton.className = 'icon-button';
+            deleteButton.dataset.action = 'delete';
+            deleteButton.dataset.entryId = String(entry.id);
+            deleteButton.setAttribute('aria-label', `Delete ${entry.name || 'entry'}`);
+            const deleteIcon = document.createElement('span');
+            deleteIcon.className = 'material-symbols-rounded';
+            deleteIcon.textContent = 'delete';
+            deleteButton.appendChild(deleteIcon);
+
+            actionsCell.append(editButton, deleteButton);
+            row.appendChild(actionsCell);
+            fragment.appendChild(row);
+        });
+        elements.tableBody.appendChild(fragment);
+    }
+
+    async function fetchEntries() {
+        if (!state.type) {
+            state.items = [];
+            applyFilters();
+            return;
+        }
+        setLoading(true);
+        try {
+            const response = await fetch(`/api/lookups/${encodeURIComponent(state.type)}`);
+            if (!response.ok) {
+                throw new Error(`Failed to load entries (${response.status})`);
+            }
+            const payload = await response.json();
+            const items = Array.isArray(payload.items) ? payload.items : [];
+            const normalized = items
+                .map((item) => {
+                    const id = item && typeof item.id !== 'undefined' ? item.id : null;
+                    const name =
+                        item && typeof item.name === 'string' ? item.name.trim() : '';
+                    return { id, name };
+                })
+                .filter((item) => item.id !== null && item.name !== '');
+            normalized.sort((a, b) =>
+                a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }),
+            );
+            state.items = normalized;
+        } catch (error) {
+            console.error(error);
+            state.items = [];
+            showToast('Failed to load entries.', 'error');
+        } finally {
+            setLoading(false);
+            applyFilters();
+        }
+    }
+
+    function openModal(backdrop, focusTarget) {
+        if (!backdrop) {
+            return;
+        }
+        lastFocusedElement = document.activeElement;
+        backdrop.hidden = false;
+        backdrop.classList.remove('hidden');
+        document.body.classList.add('modal-open');
+        if (focusTarget && typeof focusTarget.focus === 'function') {
+            focusTarget.focus();
+        }
+    }
+
+    function closeModal(backdrop) {
+        if (!backdrop) {
+            return;
+        }
+        backdrop.classList.add('hidden');
+        backdrop.hidden = true;
+        const otherOpenModal = Array.from(
+            document.querySelectorAll('.modal-backdrop'),
+        ).some((element) => element !== backdrop && !element.hidden);
+        if (!otherOpenModal) {
+            document.body.classList.remove('modal-open');
+        }
+        if (lastFocusedElement && typeof lastFocusedElement.focus === 'function') {
+            lastFocusedElement.focus();
+        }
+        lastFocusedElement = null;
+    }
+
+    function resetEntryForm() {
+        state.editingId = null;
+        if (elements.entryForm) {
+            elements.entryForm.reset();
+        }
+        if (elements.entryNameInput) {
+            elements.entryNameInput.value = '';
+        }
+        if (elements.entryModalSubtitle) {
+            elements.entryModalSubtitle.textContent = '';
+        }
+        if (elements.entrySubmit) {
+            elements.entrySubmit.disabled = false;
+            elements.entrySubmit.textContent = 'Save entry';
+        }
+    }
+
+    function openEntryModal(entry) {
+        if (!elements.entryModal || !elements.entrySubmit) {
+            return;
+        }
+        const singular = getSingularLabel(state.type);
+        state.editingId = entry ? entry.id : null;
+        if (elements.entryModalTitle) {
+            elements.entryModalTitle.textContent = entry
+                ? `Edit ${singular}`
+                : `New ${singular}`;
+        }
+        if (elements.entryModalSubtitle) {
+            elements.entryModalSubtitle.textContent = entry
+                ? `Update this ${singular.toLocaleLowerCase()} entry.`
+                : `Create a new ${singular.toLocaleLowerCase()} entry.`;
+        }
+        if (elements.entrySubmit) {
+            elements.entrySubmit.textContent = entry ? 'Save changes' : 'Create entry';
+        }
+        if (elements.entryNameInput) {
+            elements.entryNameInput.value = entry ? entry.name : '';
+        }
+        openModal(elements.entryModal, elements.entryNameInput || elements.entrySubmit);
+    }
+
+    function closeEntryModal() {
+        if (!elements.entryModal) {
+            return;
+        }
+        resetEntryForm();
+        closeModal(elements.entryModal);
+    }
+
+    function openDeleteModal(entry) {
+        if (!elements.confirmModal || !elements.confirmDelete) {
+            return;
+        }
+        state.deletingId = entry ? entry.id : null;
+        const singular = getSingularLabel(state.type);
+        if (elements.confirmSubtitle) {
+            elements.confirmSubtitle.textContent = `Remove this ${singular.toLocaleLowerCase()} from the vocabulary.`;
+        }
+        if (elements.confirmName) {
+            elements.confirmName.textContent = entry ? entry.name : '';
+        }
+        openModal(elements.confirmModal, elements.confirmDelete);
+    }
+
+    function closeDeleteModal() {
+        if (!elements.confirmModal) {
+            return;
+        }
+        state.deletingId = null;
+        if (elements.confirmSubtitle) {
+            elements.confirmSubtitle.textContent = '';
+        }
+        if (elements.confirmName) {
+            elements.confirmName.textContent = '';
+        }
+        closeModal(elements.confirmModal);
+    }
+
+    async function handleSaveEntry(event) {
+        event.preventDefault();
+        if (!elements.entryNameInput || !elements.entrySubmit) {
+            return;
+        }
+        const rawName = elements.entryNameInput.value.trim();
+        if (!rawName) {
+            elements.entryNameInput.focus();
+            return;
+        }
+        const payload = { name: rawName };
+        const submitButton = elements.entrySubmit;
+        const originalText = submitButton.textContent;
+        submitButton.disabled = true;
+        submitButton.textContent = 'Saving…';
+        try {
+            let response;
+            if (state.editingId !== null && state.editingId !== undefined) {
+                response = await fetch(
+                    `/api/lookups/${encodeURIComponent(state.type)}/${encodeURIComponent(
+                        state.editingId,
+                    )}`,
+                    {
+                        method: 'PUT',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify(payload),
+                    },
+                );
+            } else {
+                response = await fetch(`/api/lookups/${encodeURIComponent(state.type)}`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(payload),
+                });
+            }
+            if (!response || !response.ok) {
+                throw new Error('Failed to save entry');
+            }
+            closeEntryModal();
+            await fetchEntries();
+            showToast('Entry saved successfully.');
+        } catch (error) {
+            console.error(error);
+            showToast('Unable to save the entry.', 'error');
+        } finally {
+            submitButton.disabled = false;
+            submitButton.textContent = originalText;
+        }
+    }
+
+    async function handleConfirmDelete() {
+        if (state.deletingId === null || state.deletingId === undefined) {
+            closeDeleteModal();
+            return;
+        }
+        if (!elements.confirmDelete) {
+            return;
+        }
+        const button = elements.confirmDelete;
+        const originalText = button.textContent;
+        button.disabled = true;
+        button.textContent = 'Deleting…';
+        try {
+            const response = await fetch(
+                `/api/lookups/${encodeURIComponent(state.type)}/${encodeURIComponent(
+                    state.deletingId,
+                )}`,
+                {
+                    method: 'DELETE',
+                },
+            );
+            if (!response || !response.ok) {
+                throw new Error('Failed to delete entry');
+            }
+            closeDeleteModal();
+            await fetchEntries();
+            showToast('Entry deleted.');
+        } catch (error) {
+            console.error(error);
+            showToast('Unable to delete the entry.', 'error');
+        } finally {
+            button.disabled = false;
+            button.textContent = originalText;
+        }
+    }
+
+    function handleTableClick(event) {
+        if (!elements.tableBody) {
+            return;
+        }
+        const button = event.target instanceof Element ? event.target.closest('button[data-action]') : null;
+        if (!button) {
+            return;
+        }
+        const entryId = button.dataset.entryId;
+        if (!entryId) {
+            return;
+        }
+        const entry = state.items.find((item) => String(item.id) === entryId);
+        if (!entry) {
+            return;
+        }
+        if (button.dataset.action === 'edit') {
+            openEntryModal(entry);
+        } else if (button.dataset.action === 'delete') {
+            openDeleteModal(entry);
+        }
+    }
+
+    function handleTypeChange(event) {
+        const target = event.target;
+        if (!(target instanceof HTMLSelectElement)) {
+            return;
+        }
+        const { value } = target;
+        if (!value || value === state.type) {
+            return;
+        }
+        state.type = value;
+        state.search = '';
+        if (elements.searchInput) {
+            elements.searchInput.value = '';
+        }
+        setActiveLabel();
+        fetchEntries();
+    }
+
+    function handleSearchChange(event) {
+        const target = event.target;
+        if (!(target instanceof HTMLInputElement)) {
+            return;
+        }
+        state.search = target.value;
+        applyFilters();
+    }
+
+    function handleEscape(event) {
+        if (event.key !== 'Escape') {
+            return;
+        }
+        const entryModalOpen = elements.entryModal && !elements.entryModal.hidden;
+        const confirmModalOpen = elements.confirmModal && !elements.confirmModal.hidden;
+        if (confirmModalOpen) {
+            closeDeleteModal();
+        } else if (entryModalOpen) {
+            closeEntryModal();
+        }
+    }
+
+    function initialize() {
+        if (elements.typeSelect && state.type) {
+            elements.typeSelect.value = state.type;
+        } else if (elements.typeSelect && !state.type) {
+            const currentValue = elements.typeSelect.value;
+            if (currentValue) {
+                state.type = currentValue;
+            }
+        }
+        setActiveLabel();
+        updateCount();
+        fetchEntries();
+
+        if (elements.typeSelect) {
+            elements.typeSelect.addEventListener('change', handleTypeChange);
+        }
+        if (elements.searchInput) {
+            elements.searchInput.addEventListener('input', handleSearchChange);
+        }
+        if (elements.newButton) {
+            elements.newButton.addEventListener('click', () => openEntryModal(null));
+        }
+        if (elements.tableBody) {
+            elements.tableBody.addEventListener('click', handleTableClick);
+        }
+        if (elements.entryForm) {
+            elements.entryForm.addEventListener('submit', handleSaveEntry);
+        }
+        if (elements.entryCancel) {
+            elements.entryCancel.addEventListener('click', closeEntryModal);
+        }
+        if (elements.entryClose) {
+            elements.entryClose.addEventListener('click', closeEntryModal);
+        }
+        if (elements.entryModal) {
+            elements.entryModal.addEventListener('click', (event) => {
+                if (event.target === elements.entryModal) {
+                    closeEntryModal();
+                }
+            });
+        }
+        if (elements.confirmDelete) {
+            elements.confirmDelete.addEventListener('click', handleConfirmDelete);
+        }
+        if (elements.confirmCancel) {
+            elements.confirmCancel.addEventListener('click', closeDeleteModal);
+        }
+        if (elements.confirmClose) {
+            elements.confirmClose.addEventListener('click', closeDeleteModal);
+        }
+        if (elements.confirmModal) {
+            elements.confirmModal.addEventListener('click', (event) => {
+                if (event.target === elements.confirmModal) {
+                    closeDeleteModal();
+                }
+            });
+        }
+        document.addEventListener('keydown', handleEscape);
+    }
+
+    initialize();
+})();

--- a/static/style.css
+++ b/static/style.css
@@ -36,11 +36,13 @@ body {
 }
 
 body.page-editor,
-body.page-updates {
+body.page-updates,
+body.page-lookups {
   --topbar-height: 64px;
 }
 
-body.page-updates {
+body.page-updates,
+body.page-lookups {
   overflow: auto;
 }
 
@@ -924,6 +926,169 @@ textarea {
   font-size: 1.4rem;
 }
 
+.lookups-page {
+  width: min(1080px, 100% - 48px);
+  margin: 32px auto 64px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.lookups-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.lookups-title h1 {
+  margin: 0;
+  font-size: 2rem;
+  font-weight: 500;
+}
+
+.lookups-title p {
+  margin: 8px 0 0;
+  color: var(--color-muted);
+  max-width: 720px;
+}
+
+.lookups-controls {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.lookup-select {
+  min-width: 220px;
+}
+
+.lookup-select-label {
+  font-size: 0.95rem;
+  color: var(--color-muted);
+  font-weight: 500;
+}
+
+.lookups-search {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 18px;
+  border-radius: 12px;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-elevated);
+  color: var(--color-muted);
+  min-width: 240px;
+}
+
+.lookups-search input {
+  border: none;
+  background: transparent;
+  color: var(--color-text);
+  font-size: 0.95rem;
+  outline: none;
+  width: 100%;
+}
+
+.lookups-search input::placeholder {
+  color: rgba(226, 232, 240, 0.5);
+}
+
+.lookups-summary {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 0.95rem;
+  color: var(--color-muted);
+}
+
+.lookups-summary strong {
+  color: var(--color-text);
+  font-size: 1rem;
+}
+
+.lookups-summary-count {
+  color: var(--color-muted);
+}
+
+.lookups-card {
+  background: var(--color-surface-elevated);
+  border-radius: 20px;
+  border: 1px solid var(--color-border);
+  box-shadow: 0 16px 40px rgba(8, 15, 35, 0.45);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.lookups-card-header {
+  padding: 20px 24px;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.12);
+}
+
+.lookups-card-header h2 {
+  margin: 0;
+  font-size: 1.2rem;
+  font-weight: 500;
+}
+
+.lookups-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 520px;
+}
+
+.lookups-table th,
+.lookups-table td {
+  padding: 16px 24px;
+  text-align: left;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.12);
+}
+
+.lookups-table thead {
+  background: rgba(15, 23, 42, 0.3);
+}
+
+.lookups-table th {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-muted);
+}
+
+.lookups-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.lookup-name {
+  font-weight: 500;
+  color: var(--color-text);
+}
+
+.lookup-form {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.lookup-confirm p {
+  margin: 0 0 16px;
+  line-height: 1.6;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+  margin-top: 24px;
+}
+
+.lookup-confirm .modal-actions {
+  margin-top: 24px;
+}
+
 .table-empty,
 .table-loading {
   display: flex;
@@ -993,6 +1158,10 @@ textarea {
   display: flex;
   flex-direction: column;
   overflow: hidden;
+}
+
+.modal-dialog.modal-small {
+  width: min(480px, 100%);
 }
 
 .modal-header {
@@ -1142,6 +1311,15 @@ textarea {
   .modal-dialog {
     border-radius: 18px;
   }
+
+  .lookups-page {
+    width: calc(100% - 32px);
+    margin: 24px auto 48px;
+  }
+
+  .lookups-card {
+    border-radius: 18px;
+  }
 }
 
 @media (max-width: 640px) {
@@ -1173,6 +1351,27 @@ textarea {
 
   .modal-meta {
     width: 100%;
+  }
+
+  .lookups-controls {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 12px;
+  }
+
+  .lookup-select,
+  .lookups-search {
+    width: 100%;
+    min-width: 0;
+  }
+
+  .lookups-controls .btn {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .lookups-table {
+    min-width: 100%;
   }
 }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -18,7 +18,9 @@
         <div class="topbar-content">
             <a class="topbar-brand" href="{{ url_for('index') }}">Game Editor</a>
             <nav class="topbar-nav" aria-label="Global">
+                <a class="topbar-link is-active" href="{{ url_for('index') }}">Editor</a>
                 <a class="topbar-link" href="{{ url_for('updates_page') }}">IGDB Updates</a>
+                <a class="topbar-link" href="{{ url_for('lookups_page') }}">Lookups</a>
                 <a class="topbar-link" href="{{ url_for('logout') }}">Logout</a>
             </nav>
         </div>

--- a/templates/lookups.html
+++ b/templates/lookups.html
@@ -1,0 +1,142 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Lookup Vocabularies</title>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@20..48,400,0,0" />
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}" />
+</head>
+<body class="page-lookups">
+    <div id="toast" role="status" aria-live="polite"></div>
+    <header class="app-topbar" aria-label="Primary navigation">
+        <div class="topbar-content">
+            <a class="topbar-brand" href="{{ url_for('index') }}">Game Editor</a>
+            <nav class="topbar-nav" aria-label="Global">
+                <a class="topbar-link" href="{{ url_for('index') }}">Editor</a>
+                <a class="topbar-link" href="{{ url_for('updates_page') }}">IGDB Updates</a>
+                <a class="topbar-link is-active" href="{{ url_for('lookups_page') }}">Lookups</a>
+                <a class="topbar-link" href="{{ url_for('logout') }}">Logout</a>
+            </nav>
+        </div>
+    </header>
+    <main class="lookups-page">
+        <header class="lookups-header">
+            <div class="lookups-title">
+                <h1>Lookup Vocabularies</h1>
+                <p>Manage the lists of developers, publishers, genres, platforms and other shared vocabularies used throughout the catalog.</p>
+            </div>
+            <div class="lookups-controls">
+                <label class="lookup-select" for="lookup-type">
+                    <span class="lookup-select-label">Vocabulary</span>
+                    <select id="lookup-type" data-type-select>
+                        {% for lookup in lookup_tables %}
+                            <option value="{{ lookup.type }}" data-singular-label="{{ lookup.singular_label }}" {% if lookup.type == default_lookup %}selected{% endif %}>{{ lookup.label }}</option>
+                        {% endfor %}
+                    </select>
+                </label>
+                <label class="lookups-search" for="lookup-search">
+                    <span class="sr-only">Search entries</span>
+                    <span class="material-symbols-rounded" aria-hidden="true">search</span>
+                    <input
+                        type="search"
+                        id="lookup-search"
+                        placeholder="Search entries"
+                        autocomplete="off"
+                        data-search
+                    />
+                </label>
+                <button type="button" class="btn btn-green" data-new-entry>
+                    <span class="btn-icon" aria-hidden="true">
+                        <span class="material-symbols-rounded">add</span>
+                    </span>
+                    <span class="btn-label">New Entry</span>
+                </button>
+            </div>
+        </header>
+        <section class="lookups-summary" aria-live="polite">
+            <span class="lookups-summary-label">Active vocabulary:</span>
+            <strong data-active-label>{{ default_label }}</strong>
+            <span class="lookups-summary-count" data-entry-count>0 entries</span>
+        </section>
+        <section class="lookups-card">
+            <header class="lookups-card-header">
+                <h2 id="lookup-table-title">Entries</h2>
+            </header>
+            <div class="table-scroll" role="region" aria-live="polite" aria-labelledby="lookup-table-title">
+                <table class="lookups-table">
+                    <thead>
+                        <tr>
+                            <th scope="col">Name</th>
+                            <th scope="col" class="actions-column">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody data-lookup-rows></tbody>
+                </table>
+            </div>
+            <div class="table-empty" data-empty-state hidden>
+                <span class="material-symbols-rounded" aria-hidden="true">inventory_2</span>
+                <p>No entries found. Try creating a new item or adjusting your search.</p>
+            </div>
+            <div class="table-loading" data-loading-state hidden>
+                <span class="material-symbols-rounded" aria-hidden="true">hourglass_empty</span>
+                <p>Loading entries…</p>
+            </div>
+        </section>
+    </main>
+
+    <div class="modal-backdrop hidden" data-entry-modal hidden>
+        <div class="modal-dialog modal-small" role="dialog" aria-modal="true" aria-labelledby="entry-modal-title">
+            <header class="modal-header">
+                <div class="modal-titles">
+                    <h2 id="entry-modal-title">New entry</h2>
+                    <p class="modal-subtitle" data-entry-modal-subtitle></p>
+                </div>
+                <button type="button" class="icon-button" data-close-entry-modal aria-label="Close dialog">
+                    <span class="material-symbols-rounded" aria-hidden="true">close</span>
+                </button>
+            </header>
+            <form class="modal-body lookup-form" data-entry-form>
+                <label for="lookup-name">
+                    <span>Name</span>
+                    <input type="text" id="lookup-name" name="name" required data-entry-name autocomplete="off" />
+                </label>
+                <div class="modal-actions">
+                    <button type="button" class="btn btn-outline" data-cancel-entry>Cancel</button>
+                    <button type="submit" class="btn btn-green" data-entry-submit>Save entry</button>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    <div class="modal-backdrop hidden" data-confirm-modal hidden>
+        <div class="modal-dialog modal-small" role="dialog" aria-modal="true" aria-labelledby="delete-modal-title">
+            <header class="modal-header">
+                <div class="modal-titles">
+                    <h2 id="delete-modal-title">Delete entry</h2>
+                    <p class="modal-subtitle" data-delete-modal-subtitle></p>
+                </div>
+                <button type="button" class="icon-button" data-close-confirm-modal aria-label="Close dialog">
+                    <span class="material-symbols-rounded" aria-hidden="true">close</span>
+                </button>
+            </header>
+            <div class="modal-body lookup-confirm" data-confirm-body>
+                <p>Are you sure you want to delete <strong data-confirm-name></strong>? This action cannot be undone.</p>
+                <div class="modal-actions">
+                    <button type="button" class="btn btn-outline" data-cancel-delete>Cancel</button>
+                    <button type="button" class="btn btn-red" data-confirm-delete>Delete</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        window.lookupsConfig = {
+            tables: {{ lookup_tables | tojson }},
+            defaultType: {{ default_lookup | tojson }},
+        };
+    </script>
+    <script src="{{ url_for('static', filename='lookups.js') }}" defer></script>
+</body>
+</html>

--- a/templates/updates.html
+++ b/templates/updates.html
@@ -14,7 +14,9 @@
         <div class="topbar-content">
             <a class="topbar-brand" href="{{ url_for('index') }}">Game Editor</a>
             <nav class="topbar-nav" aria-label="Global">
+                <a class="topbar-link" href="{{ url_for('index') }}">Editor</a>
                 <a class="topbar-link is-active" href="{{ url_for('updates_page') }}">IGDB Updates</a>
+                <a class="topbar-link" href="{{ url_for('lookups_page') }}">Lookups</a>
                 <a class="topbar-link" href="{{ url_for('logout') }}">Logout</a>
             </nav>
         </div>


### PR DESCRIPTION
## Summary
- add a `/lookups` Flask route that renders a new management UI for lookup vocabularies
- wire the top navigation on editor and updates pages to include the lookup section
- add the HTML, CSS, and JavaScript needed to browse, create, edit, and delete lookup entries

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d38ec41ba083339c6ae2db451f6d9d