### PR TITLE
Ensure IGDB categories prefill correctly

### DIFF
--- a/app.py
+++ b/app.py
@@ -2969,11 +2969,13 @@ def generate_pt_summary(game_name: str) -> str:
 # initial load
 ensure_dirs()
 games_df = load_games()
-categories_list = sorted({
-    str(c).strip()
-    for c in games_df.get('Category', pd.Series(dtype=str)).dropna()
-    if str(c).strip()
-})
+_category_values: set[str] = set()
+for raw_category in games_df.get('Category', pd.Series(dtype=str)).dropna():
+    text = str(raw_category).strip()
+    if text:
+        _category_values.add(text)
+_category_values.update(label for label in IGDB_CATEGORY_LABELS.values() if label)
+categories_list = sorted(_category_values, key=str.casefold)
 platforms_list = sorted({
     p.strip()
     for ps in games_df.get('Platforms', pd.Series(dtype=str)).dropna()

--- a/tests/test_api_game_by_id.py
+++ b/tests/test_api_game_by_id.py
@@ -196,9 +196,11 @@ def test_build_game_payload_prefills_from_igdb(tmp_path):
     assert game['Platforms'] == ['PC', 'Switch']
     assert game['Genres'] == ['Ação e Aventura']
     assert game['GameModes'] == ['Single-player']
+    assert game['Category'] == 'Main Game'
     assert game['IGDBID'] == '123'
     assert payload['cover'] == 'cover::https://images.igdb.com/igdb/image/upload/t_original/abc123.jpg'
     assert captured_urls[-1] == 'https://images.igdb.com/igdb/image/upload/t_original/abc123.jpg'
+    assert 'Main Game' in app_module.categories_list
 
 
 def test_api_game_raw_prefills_from_igdb(tmp_path):
@@ -228,6 +230,7 @@ def test_api_game_raw_prefills_from_igdb(tmp_path):
     assert game['Platforms'] == ['PC', 'Switch']
     assert game['Genres'] == ['Ação e Aventura']
     assert game['GameModes'] == ['Single-player']
+    assert game['Category'] == 'Main Game'
     assert game['IGDBID'] == '123'
     assert data['cover'] == 'cover::https://images.igdb.com/igdb/image/upload/t_original/xyz789.jpg'
     assert captured_urls[-1] == 'https://images.igdb.com/igdb/image/upload/t_original/xyz789.jpg'


### PR DESCRIPTION
## Summary
- ensure the editor category dropdown always contains the standard IGDB category labels so API prefills are selectable
- assert in API tests that IGDB prefills populate the category field and expose the default labels

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d38f2ebe5883338e3eb5dbc1c56df8