### PR TITLE
Show duplicate updates with per-entry removal

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -881,6 +881,46 @@ textarea {
   display: block;
 }
 
+.game-info {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+}
+
+.game-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.update-tag {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px 10px;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  background: rgba(148, 163, 184, 0.16);
+  color: var(--color-muted);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+}
+
+.update-tag.is-mismatch {
+  background: rgba(37, 99, 235, 0.18);
+  color: var(--color-blue);
+  border-color: rgba(37, 99, 235, 0.45);
+}
+
+.update-tag.is-duplicate {
+  background: rgba(239, 68, 68, 0.15);
+  color: var(--color-red);
+  border-color: rgba(239, 68, 68, 0.45);
+}
+
 .game-name {
   display: block;
   line-height: 1.4;
@@ -924,6 +964,17 @@ textarea {
 
 .icon-button .material-symbols-rounded {
   font-size: 1.4rem;
+}
+
+.icon-button-danger {
+  background: rgba(239, 68, 68, 0.12);
+  color: var(--color-red);
+}
+
+.icon-button-danger:hover,
+.icon-button-danger:focus-visible {
+  background: rgba(239, 68, 68, 0.18);
+  border-color: rgba(239, 68, 68, 0.35);
 }
 
 .lookups-page {

--- a/templates/updates.html
+++ b/templates/updates.html
@@ -188,6 +188,7 @@
             cacheRefreshUrl: {{ url_for('api_igdb_cache_refresh')|tojson }},
             fixNamesUrl: {{ url_for('api_updates_fix_names')|tojson }},
             removeDuplicatesUrl: {{ url_for('api_updates_remove_duplicates')|tojson }},
+            deleteDuplicateUrlTemplate: {{ url_for('api_updates_remove_duplicate', processed_game_id=0)|replace('0', '{id}')|tojson }},
             jobsUrl: {{ url_for('api_updates_job_list')|tojson }},
             jobDetailUrlTemplate: {{ url_for('api_updates_job_detail', job_id='job')|replace('job', '{id}')|tojson }},
             detailUrlTemplate: {{ url_for('api_updates_detail', processed_game_id=0)|replace('0', '{id}')|tojson }},


### PR DESCRIPTION
## Summary
- include duplicate IGDB entries in the updates API and add an endpoint to remove a single duplicate while resequencing source indices
- tag duplicate rows in the IGDB Updates page, add a per-entry delete action, and style the new labels and buttons
- extend the updates API tests to cover duplicate listings and the new removal endpoint

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d45d323ac4833380566a8a29fb2264