### PR TITLE
Defer IGDB ingestion to update job and support optional migrations

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def enable_db_migrations(monkeypatch):
+    """Ensure database migrations run for tests that rely on migrated schema."""
+
+    monkeypatch.setenv('RUN_DB_MIGRATIONS', '1')
+    yield
+    monkeypatch.delenv('RUN_DB_MIGRATIONS', raising=False)

--- a/tests/test_navigator_state.py
+++ b/tests/test_navigator_state.py
@@ -204,6 +204,7 @@ def test_out_of_order_ids_are_normalized(tmp_path):
             [('5', '0'), ('1', '1'), ('3', '2')],
         )
     app = load_app(tmp_path)
+    app.normalize_processed_games()
     with app.db_lock:
         cur = app.db.execute(
             'SELECT "ID", "Source Index" FROM processed_games ORDER BY "ID"'


### PR DESCRIPTION
## Summary
- add environment-controlled migration flag and reuse cached processed data on startup
- refresh processed games after IGDB cache sync using new helpers instead of during import
- ensure tests request migrations explicitly and adjust navigator test to normalize on demand

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d479ffcc3c8333a8af73b07e2a38e9