### PR TITLE
Encapsulate catalog state and update tests

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,5 +1,64 @@
 """Application-wide configuration helpers and constants."""
-
 from __future__ import annotations
 
-# TODO: Populate with configuration loading utilities and shared constants.
+import os
+from pathlib import Path
+
+
+def _coerce_positive_float(value: str | None, default: float) -> float:
+    """Return ``value`` as a positive float or ``default`` when invalid."""
+
+    try:
+        numeric = float(value) if value is not None else default
+    except (TypeError, ValueError):
+        return default
+    return numeric if numeric > 0 else default
+
+
+def _coerce_truthy_env(value: str | None) -> bool:
+    """Return ``True`` when ``value`` represents an affirmative flag."""
+
+    if value is None:
+        return False
+    text = value.strip().lower()
+    return text in {"1", "true", "yes", "on"}
+
+
+BASE_DIR = Path(__file__).resolve().parent
+INPUT_XLSX = "igdb_all_games.xlsx"
+PROCESSED_DB = "processed_games.db"
+UPLOAD_DIR = "uploaded_sources"
+PROCESSED_DIR = "processed_covers"
+COVERS_DIR = "covers_out"
+
+DEFAULT_IGDB_USER_AGENT = "TT-Game-Liste/1.0 (support@example.com)"
+
+SQLITE_TIMEOUT_SECONDS = _coerce_positive_float(os.environ.get("SQLITE_TIMEOUT"), 120.0)
+RUN_DB_MIGRATIONS = _coerce_truthy_env(os.environ.get("RUN_DB_MIGRATIONS"))
+APP_SECRET_KEY = os.environ.get("APP_SECRET_KEY", "dev-secret")
+APP_PASSWORD = os.environ.get("APP_PASSWORD", "password")
+IGDB_USER_AGENT = os.environ.get("IGDB_USER_AGENT") or DEFAULT_IGDB_USER_AGENT
+OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY", "")
+
+
+def get_lookup_data_dir() -> Path:
+    """Return the directory containing lookup workbook files."""
+
+    return Path(os.environ.get("LOOKUP_DATA_DIR", BASE_DIR))
+
+__all__ = [
+    "APP_PASSWORD",
+    "APP_SECRET_KEY",
+    "BASE_DIR",
+    "COVERS_DIR",
+    "DEFAULT_IGDB_USER_AGENT",
+    "IGDB_USER_AGENT",
+    "INPUT_XLSX",
+    "get_lookup_data_dir",
+    "OPENAI_API_KEY",
+    "PROCESSED_DB",
+    "PROCESSED_DIR",
+    "RUN_DB_MIGRATIONS",
+    "SQLITE_TIMEOUT_SECONDS",
+    "UPLOAD_DIR",
+]

--- a/helpers.py
+++ b/helpers.py
@@ -1,0 +1,198 @@
+"""General-purpose helper utilities shared across the application."""
+
+from __future__ import annotations
+
+import numbers
+from datetime import datetime, timezone
+from typing import Any, Iterable, Mapping
+
+import pandas as pd
+
+
+__all__ = [
+    "_collect_company_names",
+    "_dedupe_preserve_order",
+    "_format_first_release_date",
+    "_format_name_list",
+    "_normalize_lookup_name",
+    "_parse_company_names",
+    "_parse_iterable",
+    "has_cover_path_value",
+    "has_summary_text",
+]
+
+
+def has_summary_text(value: Any) -> bool:
+    """Return ``True`` when ``value`` contains non-empty summary text."""
+
+    if value is None:
+        return False
+    if isinstance(value, str):
+        text = value.strip()
+    else:
+        try:
+            if pd.isna(value):
+                return False
+        except Exception:
+            pass
+        text = str(value).strip()
+    if not text:
+        return False
+    if text.lower() == "nan":
+        return False
+    return True
+
+
+def has_cover_path_value(value: Any) -> bool:
+    """Return ``True`` when ``value`` contains a usable cover path."""
+
+    if value is None:
+        return False
+    if isinstance(value, str):
+        text = value.strip()
+    else:
+        try:
+            if pd.isna(value):
+                return False
+        except Exception:
+            pass
+        text = str(value).strip()
+    if not text:
+        return False
+    if text.lower() == "nan":
+        return False
+    return True
+
+
+def _dedupe_preserve_order(values: Iterable[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        text = str(value).strip()
+        if not text:
+            continue
+        key = text.casefold()
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(text)
+    return result
+
+
+def _format_name_list(value: Any) -> str:
+    return ", ".join(_dedupe_preserve_order(_parse_iterable(value)))
+
+
+def _collect_company_names(
+    companies: Any, role_key: str
+) -> list[str]:  # pragma: no cover - simple data formatter
+    names: list[str] = []
+    if isinstance(companies, list):
+        for company in companies:
+            if not isinstance(company, Mapping):
+                continue
+            if not company.get(role_key):
+                continue
+            company_obj = company.get("company")
+            name_value: Any = None
+            if isinstance(company_obj, Mapping):
+                name_value = company_obj.get("name")
+            elif isinstance(company_obj, str):
+                name_value = company_obj
+            if not name_value:
+                continue
+            text = str(name_value).strip()
+            if text:
+                names.append(text)
+    return _dedupe_preserve_order(names)
+
+
+def _format_first_release_date(value: Any) -> str:
+    if value in (None, "", 0):
+        return ""
+    try:
+        timestamp = float(value)
+    except (TypeError, ValueError):
+        try:
+            timestamp = float(str(value).strip())
+        except (TypeError, ValueError):
+            return ""
+    if timestamp <= 0:
+        return ""
+    try:
+        dt = datetime.fromtimestamp(timestamp, tz=timezone.utc)
+    except (OverflowError, OSError, ValueError):
+        return ""
+    return dt.date().isoformat()
+
+
+def _normalize_lookup_name(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value.strip()
+    try:
+        if pd.isna(value):
+            return ""
+    except Exception:
+        pass
+    return str(value).strip()
+
+
+def _parse_iterable(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [v.strip() for v in value.split(',') if v.strip()]
+    if isinstance(value, numbers.Number):
+        return [str(value)]
+    try:
+        iterator = iter(value)
+    except TypeError:
+        return [str(value)]
+    items: list[str] = []
+    for element in iterator:
+        if isinstance(element, Mapping):
+            name = element.get("name")
+            if isinstance(name, str) and name.strip():
+                items.append(name.strip())
+            else:
+                items.append(str(element).strip())
+        else:
+            items.append(str(element).strip())
+    return [item for item in items if item]
+
+
+def _parse_company_names(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        cleaned = value.strip()
+        return [cleaned] if cleaned else []
+    if isinstance(value, numbers.Number):
+        return [str(value)]
+    names: list[str] = []
+    try:
+        iterator = iter(value)
+    except TypeError:
+        text = str(value).strip()
+        return [text] if text else []
+    for element in iterator:
+        name_value: Any = None
+        if isinstance(element, Mapping):
+            if isinstance(element.get("name"), str):
+                name_value = element["name"]
+            else:
+                company_obj = element.get("company")
+                if isinstance(company_obj, Mapping) and isinstance(
+                    company_obj.get("name"), str
+                ):
+                    name_value = company_obj["name"]
+                elif isinstance(company_obj, str):
+                    name_value = company_obj
+        else:
+            name_value = element
+        text = _normalize_lookup_name(name_value)
+        if text:
+            names.append(text)
+    return names

--- a/igdb/client.py
+++ b/igdb/client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import numbers
 import os
 from typing import Any, Callable, Iterable, Mapping
 
@@ -11,8 +12,287 @@ from urllib.error import HTTPError
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen
 
+import pandas as pd
+
+from helpers import _normalize_lookup_name
+
 
 logger = logging.getLogger(__name__)
+
+
+__all__ = [
+    "cover_url_from_cover",
+    "coerce_igdb_id",
+    "extract_igdb_id",
+    "exchange_twitch_credentials",
+    "download_igdb_metadata",
+    "download_igdb_game_count",
+    "download_igdb_games",
+    "map_igdb_genres",
+    "map_igdb_modes",
+    "resolve_igdb_page_size",
+]
+
+
+def resolve_igdb_page_size(batch_size: Any, *, max_page_size: int = 500) -> int:
+    """Return a sanitized IGDB page size respecting API constraints."""
+
+    try:
+        size = int(batch_size)
+    except (TypeError, ValueError):
+        return max_page_size
+    if size <= 0:
+        return max_page_size
+    return min(size, max_page_size)
+
+
+def cover_url_from_cover(value: Any, size: str = "t_cover_big") -> str:
+    """Return the IGDB image URL for a cover payload or identifier."""
+
+    image_id: str | None = None
+    if isinstance(value, Mapping):
+        raw_id = value.get("image_id")
+        if isinstance(raw_id, str):
+            image_id = raw_id.strip()
+        elif raw_id is not None:
+            image_id = str(raw_id).strip()
+    elif isinstance(value, str):
+        image_id = value.strip()
+    elif value is not None:
+        image_id = str(value).strip()
+    if not image_id:
+        return ""
+    size_key = str(size).strip() if size else "t_cover_big"
+    if not size_key:
+        size_key = "t_cover_big"
+    return "https://images.igdb.com/igdb/image/upload/" f"{size_key}/{image_id}.jpg"
+
+
+def coerce_igdb_id(value: Any) -> str:
+    """Normalize potential IGDB identifiers to a canonical string."""
+
+    if value is None:
+        return ""
+    try:
+        if pd.isna(value):
+            return ""
+    except Exception:
+        pass
+    if isinstance(value, str):
+        text = value.strip()
+        if not text or text.lower() == "nan":
+            return ""
+        if text.endswith(".0") and text[:-2].isdigit():
+            return text[:-2]
+        return text
+    if isinstance(value, numbers.Integral):
+        return str(int(value))
+    if isinstance(value, numbers.Real):
+        if float(value).is_integer():
+            return str(int(value))
+        return str(value)
+    text = str(value).strip()
+    if not text or text.lower() == "nan":
+        return ""
+    return text
+
+
+def extract_igdb_id(row: pd.Series, allow_generic_id: bool = False) -> str:
+    """Extract an IGDB identifier from a row, optionally falling back to ``id``."""
+
+    for key in row.index:
+        normalized = _normalize_column_name(key)
+        if "igdb" in normalized and "id" in normalized:
+            value = coerce_igdb_id(row.get(key))
+            if value:
+                return value
+    if allow_generic_id:
+        for key in row.index:
+            key_str = str(key)
+            if key_str.lower() == "id":
+                value = coerce_igdb_id(row.get(key))
+                if value:
+                    return value
+    return ""
+
+
+def _normalize_column_name(name: str) -> str:
+    return "".join(ch.lower() for ch in str(name) if ch.isalnum())
+
+
+def map_igdb_genres(names: Iterable[str]) -> list[str]:
+    """Return localized genre names derived from IGDB values."""
+
+    return _map_igdb_values(names, IGDB_GENRE_TRANSLATIONS)
+
+
+def map_igdb_modes(names: Iterable[str]) -> list[str]:
+    """Return localized game mode names derived from IGDB values."""
+
+    return _map_igdb_values(names, IGDB_MODE_TRANSLATIONS)
+
+
+def _map_igdb_values(
+    names: Iterable[str], translations: Mapping[str, tuple[str, ...]]
+) -> list[str]:
+    results: list[str] = []
+    seen: set[str] = set()
+    for raw_name in names:
+        normalized = _normalize_lookup_name(raw_name)
+        if not normalized:
+            continue
+        key = _normalize_translation_key(normalized)
+        mapped = translations.get(key)
+        if not mapped:
+            mapped = (normalized,)
+        for candidate in mapped:
+            final = _normalize_lookup_name(candidate)
+            if not final:
+                continue
+            dedupe_key = final.casefold()
+            if dedupe_key in seen:
+                continue
+            seen.add(dedupe_key)
+            results.append(final)
+    return results
+
+
+def _normalize_translation_key(value: str) -> str:
+    key = str(value).strip().casefold()
+    for old, new in (
+        ("&", " and "),
+        ("/", " "),
+        ("-", " "),
+        ("_", " "),
+        ("'", ""),
+        (",", " "),
+        (".", " "),
+        ("+", " "),
+    ):
+        key = key.replace(old, new)
+    for char in "()[]{}":
+        key = key.replace(char, " ")
+    key = "".join(ch for ch in key if ch.isalnum() or ch.isspace())
+    return " ".join(key.split())
+
+
+IGDB_GENRE_TRANSLATIONS: dict[str, tuple[str, ...]] = {
+    _normalize_translation_key("Action"): ("Ação e Aventura",),
+    _normalize_translation_key("Action Adventure"): ("Ação e Aventura",),
+    _normalize_translation_key("Adventure"): ("Ação e Aventura",),
+    _normalize_translation_key("Point-and-click"): ("Ação e Aventura",),
+    _normalize_translation_key("Stealth"): ("Ação e Aventura",),
+    _normalize_translation_key("Survival"): ("Ação e Aventura",),
+    _normalize_translation_key("Platform"): ("Plataformas",),
+    _normalize_translation_key("Platformer"): ("Plataformas",),
+    _normalize_translation_key("Shooter"): ("Tiro",),
+    _normalize_translation_key("Shoot 'em up"): ("Tiro",),
+    _normalize_translation_key("Fighting"): ("Luta",),
+    _normalize_translation_key("Hack and slash/Beat 'em up"): ("Luta",),
+    _normalize_translation_key("Brawler"): ("Luta",),
+    _normalize_translation_key("Racing"): ("Corrida e Voo",),
+    _normalize_translation_key("Driving Racing"): ("Corrida e Voo",),
+    _normalize_translation_key("Flight"): ("Corrida e Voo",),
+    _normalize_translation_key("Simulator"): ("Simulação",),
+    _normalize_translation_key("Simulation"): ("Simulação",),
+    _normalize_translation_key("Strategy"): ("Estratégia",),
+    _normalize_translation_key("Real Time Strategy (RTS)"): ("Estratégia",),
+    _normalize_translation_key("Turn-based strategy (TBS)"): ("Estratégia",),
+    _normalize_translation_key("Tactical"): ("Estratégia",),
+    _normalize_translation_key("MOBA"): ("Multijogador",),
+    _normalize_translation_key("Massively Multiplayer Online (MMO)"): ("Multijogador",),
+    _normalize_translation_key("Battle Royale"): ("Multijogador",),
+    _normalize_translation_key("MMORPG"): ("RPG", "Multijogador"),
+    _normalize_translation_key("Role-playing (RPG)"): ("RPG",),
+    _normalize_translation_key("Role playing"): ("RPG",),
+    _normalize_translation_key("Roguelike"): ("RPG",),
+    _normalize_translation_key("Roguelite"): ("RPG",),
+    _normalize_translation_key("Puzzle"): ("Quebra-cabeça e Trivia",),
+    _normalize_translation_key("Quiz/Trivia"): ("Quebra-cabeça e Trivia",),
+    _normalize_translation_key("Trivia"): ("Quebra-cabeça e Trivia",),
+    _normalize_translation_key("Card & Board Game"): ("Cartas e Tabuleiro",),
+    _normalize_translation_key("Board game"): ("Cartas e Tabuleiro",),
+    _normalize_translation_key("Tabletop"): ("Cartas e Tabuleiro",),
+    _normalize_translation_key("Family"): ("Família e Crianças",),
+    _normalize_translation_key("Kids"): ("Família e Crianças",),
+    _normalize_translation_key("Educational"): ("Família e Crianças",),
+    _normalize_translation_key("Party"): ("Família e Crianças",),
+    _normalize_translation_key("Music"): ("Família e Crianças",),
+    _normalize_translation_key("Indie"): ("Indie",),
+    _normalize_translation_key("Arcade"): ("Clássicos",),
+    _normalize_translation_key("Pinball"): ("Clássicos",),
+    _normalize_translation_key("Classic"): ("Clássicos",),
+    _normalize_translation_key("Visual Novel"): ("Visual Novel",),
+    _normalize_translation_key("ação e aventura"): ("Ação e Aventura",),
+    _normalize_translation_key("plataformas"): ("Plataformas",),
+    _normalize_translation_key("tiro"): ("Tiro",),
+    _normalize_translation_key("luta"): ("Luta",),
+    _normalize_translation_key("corrida e voo"): ("Corrida e Voo",),
+    _normalize_translation_key("simulação"): ("Simulação",),
+    _normalize_translation_key("estratégia"): ("Estratégia",),
+    _normalize_translation_key("multijogador"): ("Multijogador",),
+    _normalize_translation_key("rpg"): ("RPG",),
+    _normalize_translation_key("quebra-cabeça e trivia"): ("Quebra-cabeça e Trivia",),
+    _normalize_translation_key("cartas e tabuleiro"): ("Cartas e Tabuleiro",),
+    _normalize_translation_key("família e crianças"): ("Família e Crianças",),
+    _normalize_translation_key("indie"): ("Indie",),
+    _normalize_translation_key("clássicos"): ("Clássicos",),
+    _normalize_translation_key("visual novel"): ("Visual Novel",),
+}
+
+
+IGDB_MODE_TRANSLATIONS: dict[str, tuple[str, ...]] = {
+    _normalize_translation_key("Single player"): ("Single-player",),
+    _normalize_translation_key("Single-player"): ("Single-player",),
+    _normalize_translation_key("Singleplayer"): ("Single-player",),
+    _normalize_translation_key("Solo"): ("Single-player",),
+    _normalize_translation_key("Campaign"): ("Single-player",),
+    _normalize_translation_key("Co-operative"): ("Cooperativo (Co-op)",),
+    _normalize_translation_key("Cooperative"): ("Cooperativo (Co-op)",),
+    _normalize_translation_key("Co-op"): ("Cooperativo (Co-op)",),
+    _normalize_translation_key("Co op"): ("Cooperativo (Co-op)",),
+    _normalize_translation_key("Local co-op"): (
+        "Cooperativo (Co-op)",
+        "Multiplayer local",
+    ),
+    _normalize_translation_key("Offline co-op"): (
+        "Cooperativo (Co-op)",
+        "Multiplayer local",
+    ),
+    _normalize_translation_key("Online co-op"): (
+        "Cooperativo (Co-op)",
+        "Multiplayer online",
+    ),
+    _normalize_translation_key("Co-op campaign"): ("Cooperativo (Co-op)",),
+    _normalize_translation_key("Multiplayer"): ("Multiplayer online",),
+    _normalize_translation_key("Online multiplayer"): ("Multiplayer online",),
+    _normalize_translation_key("Multiplayer online"): ("Multiplayer online",),
+    _normalize_translation_key("Offline multiplayer"): ("Multiplayer local",),
+    _normalize_translation_key("Local multiplayer"): ("Multiplayer local",),
+    _normalize_translation_key("Split screen"): ("Multiplayer local",),
+    _normalize_translation_key("Shared/Split screen"): ("Multiplayer local",),
+    _normalize_translation_key("PvP"): ("Competitivo (PvP)",),
+    _normalize_translation_key("Player vs Player"): ("Competitivo (PvP)",),
+    _normalize_translation_key("Versus"): ("Competitivo (PvP)",),
+    _normalize_translation_key("Competitive"): ("Competitivo (PvP)",),
+    _normalize_translation_key("Battle Royale"): (
+        "Multiplayer online",
+        "Competitivo (PvP)",
+    ),
+    _normalize_translation_key("Massively Multiplayer Online (MMO)"): (
+        "Multiplayer online",
+    ),
+    _normalize_translation_key("MMO"): ("Multiplayer online",),
+    _normalize_translation_key("MMORPG"): (
+        "RPG",
+        "Multiplayer online",
+    ),
+    _normalize_translation_key("single-player"): ("Single-player",),
+    _normalize_translation_key("cooperativo (co-op)"): ("Cooperativo (Co-op)",),
+    _normalize_translation_key("multiplayer local"): ("Multiplayer local",),
+    _normalize_translation_key("multiplayer online"): ("Multiplayer online",),
+    _normalize_translation_key("competitivo (pvp)"): ("Competitivo (PvP)",),
+}
 
 
 def exchange_twitch_credentials(

--- a/init.py
+++ b/init.py
@@ -1,0 +1,63 @@
+"""Application startup orchestration helpers."""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from typing import Callable
+
+import pandas as pd
+
+from config import RUN_DB_MIGRATIONS
+from db import utils as db_utils
+
+logger = logging.getLogger(__name__)
+
+
+def initialize_app(
+    *,
+    ensure_dirs: Callable[[], None],
+    init_db: Callable[..., None],
+    load_games: Callable[..., pd.DataFrame],
+    set_games_dataframe: Callable[..., None],
+    connection_factory: Callable[[], sqlite3.Connection],
+    run_migrations: bool = RUN_DB_MIGRATIONS,
+    rebuild_metadata: bool = True,
+    rebuild_navigator: bool = True,
+    prefer_cache: bool = False,
+) -> sqlite3.Connection:
+    """Perform the core startup tasks required for the application.
+
+    The initializer ensures filesystem directories exist, prepares the processed
+    games database (including migrations and lookup seeding), establishes the
+    fallback SQLite connection, and loads the source games workbook into the
+    in-memory navigator state.
+
+    Parameters mirror the existing helper functions in :mod:`app` so that the
+    orchestration can remain testable and reusable from scripts.
+    """
+
+    ensure_dirs()
+
+    init_db(run_migrations=run_migrations)
+
+    connection = connection_factory()
+    db_utils.set_fallback_connection(connection)
+
+    games_df = load_games(prefer_cache=prefer_cache)
+
+    try:
+        set_games_dataframe(
+            games_df,
+            rebuild_metadata=rebuild_metadata,
+            rebuild_navigator=rebuild_navigator,
+        )
+    except Exception:
+        logger.exception("Failed to configure navigator state during startup")
+        raise
+
+    return connection
+
+
+__all__ = ["initialize_app"]
+

--- a/jobs/manager.py
+++ b/jobs/manager.py
@@ -2,4 +2,255 @@
 
 from __future__ import annotations
 
-# TODO: Implement background job dataclasses and manager logic for async tasks.
+import logging
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from threading import Lock, Thread
+from typing import Any, Callable, Mapping, Optional
+
+logger = logging.getLogger(__name__)
+
+
+MAX_BACKGROUND_JOBS = 50
+
+
+def _job_timestamp() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+JOB_STATUS_PENDING = 'pending'
+JOB_STATUS_RUNNING = 'running'
+JOB_STATUS_SUCCESS = 'success'
+JOB_STATUS_ERROR = 'error'
+JOB_ACTIVE_STATUSES = {JOB_STATUS_PENDING, JOB_STATUS_RUNNING}
+JOB_TERMINAL_STATUSES = {JOB_STATUS_SUCCESS, JOB_STATUS_ERROR}
+
+
+@dataclass
+class BackgroundJob:
+    id: str
+    job_type: str
+    status: str = JOB_STATUS_PENDING
+    message: str = ''
+    progress_current: int = 0
+    progress_total: int = 0
+    data: dict[str, Any] = field(default_factory=dict)
+    result: dict[str, Any] = field(default_factory=dict)
+    error: Optional[str] = None
+    created_at: str = ''
+    updated_at: str = ''
+    started_at: Optional[str] = None
+    finished_at: Optional[str] = None
+
+
+class BackgroundJobManager:
+    def __init__(self) -> None:
+        self._jobs: dict[str, BackgroundJob] = {}
+        self._lock = Lock()
+
+    def _serialize_job(self, job: BackgroundJob) -> dict[str, Any]:
+        return {
+            'id': job.id,
+            'job_type': job.job_type,
+            'status': job.status,
+            'message': job.message,
+            'progress_current': job.progress_current,
+            'progress_total': job.progress_total,
+            'data': dict(job.data),
+            'result': dict(job.result),
+            'error': job.error,
+            'created_at': job.created_at,
+            'updated_at': job.updated_at,
+            'started_at': job.started_at,
+            'finished_at': job.finished_at,
+        }
+
+    def _find_active_job_locked(self, job_type: str) -> Optional[BackgroundJob]:
+        for job in self._jobs.values():
+            if job.job_type == job_type and job.status in JOB_ACTIVE_STATUSES:
+                return job
+        return None
+
+    def _prune_jobs_locked(self) -> None:
+        if len(self._jobs) <= MAX_BACKGROUND_JOBS:
+            return
+        removable: list[BackgroundJob] = [
+            job
+            for job in self._jobs.values()
+            if job.status in JOB_TERMINAL_STATUSES
+        ]
+        removable.sort(key=lambda j: j.finished_at or j.updated_at)
+        while len(self._jobs) > MAX_BACKGROUND_JOBS and removable:
+            victim = removable.pop(0)
+            self._jobs.pop(victim.id, None)
+
+    def list_jobs(self, job_type: str | None = None) -> list[dict[str, Any]]:
+        with self._lock:
+            jobs = list(self._jobs.values())
+            if job_type:
+                jobs = [job for job in jobs if job.job_type == job_type]
+            jobs.sort(key=lambda job: job.created_at)
+            return [self._serialize_job(job) for job in jobs]
+
+    def get_job(self, job_id: str) -> Optional[dict[str, Any]]:
+        with self._lock:
+            job = self._jobs.get(job_id)
+            if job is None:
+                return None
+            return self._serialize_job(job)
+
+    def get_active_job(self, job_type: str) -> Optional[dict[str, Any]]:
+        with self._lock:
+            job = self._find_active_job_locked(job_type)
+            if job is None:
+                return None
+            return self._serialize_job(job)
+
+    def start_job(
+        self,
+        job_type: str,
+        runner: Callable[[Callable[..., None]], Optional[dict[str, Any]]],
+        *,
+        description: str | None = None,
+    ) -> tuple[dict[str, Any], bool]:
+        with self._lock:
+            existing = self._find_active_job_locked(job_type)
+            if existing is not None:
+                return self._serialize_job(existing), False
+            job_id = uuid.uuid4().hex
+            timestamp = _job_timestamp()
+            job = BackgroundJob(
+                id=job_id,
+                job_type=job_type,
+                message=description or '',
+                created_at=timestamp,
+                updated_at=timestamp,
+            )
+            self._jobs[job_id] = job
+            self._prune_jobs_locked()
+
+        thread = Thread(
+            target=self._run_job,
+            args=(job_id, runner),
+            name=f'job-{job_type}-{job_id}',
+            daemon=True,
+        )
+        thread.start()
+        return self.get_job(job_id), True
+
+    def _set_job_running(self, job_id: str) -> None:
+        timestamp = _job_timestamp()
+        with self._lock:
+            job = self._jobs.get(job_id)
+            if job is None:
+                return
+            job.status = JOB_STATUS_RUNNING
+            job.started_at = timestamp
+            job.updated_at = timestamp
+            if not job.message:
+                job.message = 'Running…'
+
+    def _update_job(
+        self,
+        job_id: str,
+        *,
+        progress_current: int | None = None,
+        progress_total: int | None = None,
+        message: str | None = None,
+        data: Optional[Mapping[str, Any]] = None,
+    ) -> None:
+        timestamp = _job_timestamp()
+        with self._lock:
+            job = self._jobs.get(job_id)
+            if job is None:
+                return
+            if progress_current is not None:
+                job.progress_current = max(int(progress_current), 0)
+            if progress_total is not None:
+                job.progress_total = max(int(progress_total), 0)
+            if message is not None:
+                job.message = str(message)
+            if data:
+                for key, value in data.items():
+                    job.data[key] = value
+            job.updated_at = timestamp
+
+    def _finalize_job(
+        self,
+        job_id: str,
+        status: str,
+        result: Optional[dict[str, Any]] = None,
+        error: Optional[str] = None,
+    ) -> None:
+        timestamp = _job_timestamp()
+        with self._lock:
+            job = self._jobs.get(job_id)
+            if job is None:
+                return
+            job.status = status
+            job.error = error
+            job.result = dict(result or {})
+            job.finished_at = timestamp
+            job.updated_at = timestamp
+
+    def _run_job(
+        self,
+        job_id: str,
+        runner: Callable[[Callable[..., None]], Optional[dict[str, Any]]],
+    ) -> None:
+        def progress_callback(
+            current: int | None = None,
+            total: int | None = None,
+            message: str | None = None,
+            *,
+            data: Optional[Mapping[str, Any]] = None,
+            **extra: Any,
+        ) -> None:
+            merged: dict[str, Any] = {}
+            if data:
+                merged.update(dict(data))
+            if extra:
+                merged.update({k: v for k, v in extra.items() if v is not None})
+            self._update_job(
+                job_id,
+                progress_current=current,
+                progress_total=total,
+                message=message,
+                data=merged or None,
+            )
+
+        self._set_job_running(job_id)
+        try:
+            result = runner(progress_callback)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.exception('Background job %s failed', job_id)
+            self._finalize_job(job_id, JOB_STATUS_ERROR, error=str(exc))
+            return
+        self._finalize_job(job_id, JOB_STATUS_SUCCESS, result=result)
+
+
+_JOB_MANAGER: BackgroundJobManager | None = None
+
+
+def get_job_manager() -> BackgroundJobManager:
+    """Return the process-wide :class:`BackgroundJobManager` instance."""
+
+    global _JOB_MANAGER
+    if _JOB_MANAGER is None:
+        _JOB_MANAGER = BackgroundJobManager()
+    return _JOB_MANAGER
+
+
+__all__ = [
+    'BackgroundJob',
+    'BackgroundJobManager',
+    'JOB_ACTIVE_STATUSES',
+    'JOB_STATUS_ERROR',
+    'JOB_STATUS_PENDING',
+    'JOB_STATUS_RUNNING',
+    'JOB_STATUS_SUCCESS',
+    'JOB_TERMINAL_STATUSES',
+    'MAX_BACKGROUND_JOBS',
+    'get_job_manager',
+]

--- a/lookups/service.py
+++ b/lookups/service.py
@@ -2,4 +2,281 @@
 
 from __future__ import annotations
 
-# TODO: Implement services for managing lookup records and related joins.
+from typing import Any, Callable, Iterable, Mapping, MutableMapping, Sequence
+
+import sqlite3
+
+from db import utils as db_utils
+
+
+def _coerce_int(value: Any) -> int | None:
+    """Best-effort conversion of ``value`` to ``int``."""
+
+    try:
+        return int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+
+
+def _replace_relations(
+    conn: sqlite3.Connection,
+    join_table: str,
+    join_column: str,
+    processed_game_id: int,
+    lookup_ids: Iterable[int],
+) -> None:
+    """Replace ``processed_game_id`` relations in ``join_table`` with ``lookup_ids``."""
+
+    try:
+        conn.execute(
+            f"DELETE FROM {join_table} WHERE processed_game_id = ?",
+            (processed_game_id,),
+        )
+    except sqlite3.OperationalError:
+        return
+
+    to_insert: list[tuple[int, int]] = []
+    for value in lookup_ids:
+        coerced = _coerce_int(value)
+        if coerced is None:
+            continue
+        to_insert.append((processed_game_id, coerced))
+
+    if not to_insert:
+        return
+
+    try:
+        conn.executemany(
+            f"INSERT OR IGNORE INTO {join_table} "
+            f"(processed_game_id, {join_column}) VALUES (?, ?)",
+            to_insert,
+        )
+    except sqlite3.OperationalError:
+        return
+
+
+def persist_relations(
+    conn: sqlite3.Connection,
+    processed_game_id: int,
+    selections: Mapping[str, Mapping[str, Any]] | Mapping[str, Any],
+    relations: Sequence[Mapping[str, Any]],
+) -> None:
+    """Persist lookup selections for ``processed_game_id``."""
+
+    for relation in relations:
+        response_key = relation["response_key"]
+        join_table = relation["join_table"]
+        join_column = relation["join_column"]
+
+        ids: list[int] = []
+        selection: Any = None
+        if isinstance(selections, Mapping):
+            selection = selections.get(response_key)
+        if isinstance(selection, Mapping):
+            raw_ids = selection.get("ids")
+            if isinstance(raw_ids, (list, tuple)):
+                ids = [value for value in raw_ids if value is not None]
+
+        _replace_relations(conn, join_table, join_column, processed_game_id, ids)
+
+
+def lookup_entries_to_selection(
+    entries: Mapping[str, Sequence[Mapping[str, Any]]],
+    relations: Sequence[Mapping[str, Any]],
+) -> dict[str, dict[str, list[int]]]:
+    """Convert lookup entries into the selections payload expected by editors."""
+
+    payload: dict[str, dict[str, list[int]]] = {}
+
+    for relation in relations:
+        response_key = relation["response_key"]
+        relation_entries = entries.get(response_key, []) or []
+        ids: list[int] = []
+        for entry in relation_entries:
+            if not isinstance(entry, Mapping):
+                continue
+            entry_id = _coerce_int(entry.get("id"))
+            if entry_id is None:
+                continue
+            ids.append(entry_id)
+        payload[response_key] = {"ids": ids}
+
+    return payload
+
+
+def apply_relations_to_game(
+    conn: sqlite3.Connection,
+    processed_game_id: int,
+    entries: Mapping[str, Sequence[Mapping[str, Any]]],
+    relations: Sequence[Mapping[str, Any]],
+    *,
+    normalize_lookup_name: Callable[[Any], str],
+    encode_lookup_id_list: Callable[[Iterable[int]], str],
+    lookup_display_text: Callable[[list[str]], str],
+    columns: set[str] | None = None,
+) -> None:
+    """Write lookup entry metadata back to ``processed_games`` columns."""
+
+    if columns is None:
+        columns = db_utils.get_processed_games_columns(conn)
+
+    set_fragments: list[str] = []
+    params: list[Any] = []
+
+    for relation in relations:
+        response_key = relation["response_key"]
+        processed_column = relation["processed_column"]
+        id_column = relation.get("id_column")
+        relation_entries = entries.get(response_key, []) or []
+
+        if processed_column in columns:
+            names: list[str] = []
+            for entry in relation_entries:
+                if not isinstance(entry, Mapping):
+                    continue
+                normalized = normalize_lookup_name(entry.get("name"))
+                if normalized:
+                    names.append(normalized)
+            set_fragments.append(
+                f"{db_utils._quote_identifier(processed_column)} = ?"
+            )
+            params.append(lookup_display_text(names))
+
+        if id_column and id_column in columns:
+            ids: list[int] = []
+            for entry in relation_entries:
+                if not isinstance(entry, Mapping):
+                    continue
+                coerced = _coerce_int(entry.get("id"))
+                if coerced is None:
+                    continue
+                ids.append(coerced)
+            set_fragments.append(f"{db_utils._quote_identifier(id_column)} = ?")
+            params.append(encode_lookup_id_list(ids))
+
+    if not set_fragments:
+        return
+
+    params.append(processed_game_id)
+    conn.execute(
+        f"UPDATE processed_games SET {', '.join(set_fragments)} WHERE \"ID\" = ?",
+        params,
+    )
+
+
+def remove_lookup_id_from_entries(
+    entries: MutableMapping[str, list[Mapping[str, Any]]],
+    relation: Mapping[str, Any],
+    lookup_id: int,
+) -> None:
+    """Remove ``lookup_id`` from cached relation entries."""
+
+    response_key = relation["response_key"]
+    relation_entries = list(entries.get(response_key, []) or [])
+    filtered: list[Mapping[str, Any]] = []
+
+    for entry in relation_entries:
+        if not isinstance(entry, Mapping):
+            continue
+        coerced = _coerce_int(entry.get("id"))
+        if coerced == lookup_id:
+            continue
+        filtered.append(entry)
+
+    entries[response_key] = filtered
+
+
+def backfill_relations(
+    conn: sqlite3.Connection,
+    relations: Sequence[Mapping[str, Any]],
+    *,
+    normalize_lookup_name: Callable[[Any], str],
+    parse_iterable: Callable[[Any], Iterable[str]],
+    get_or_create_lookup_id: Callable[[sqlite3.Connection, str, str], int | None],
+    decode_lookup_id_list: Callable[[Any], Iterable[int]],
+    row_value: Callable[[sqlite3.Row | Sequence[Any], str, int], Any],
+) -> None:
+    """Populate join tables using existing processed-game values."""
+
+    try:
+        cur = conn.execute("SELECT * FROM processed_games")
+    except sqlite3.OperationalError:
+        return
+
+    rows = cur.fetchall()
+    column_names = [desc[0] for desc in cur.description] if cur.description else []
+
+    for row in rows:
+        if isinstance(row, sqlite3.Row):
+            row_dict = dict(row)
+        else:
+            row_dict = {
+                column_names[idx]: value
+                for idx, value in enumerate(row)
+                if idx < len(column_names)
+            }
+
+        try:
+            game_id = int(row_dict.get("ID"))
+        except (TypeError, ValueError):
+            continue
+
+        for relation in relations:
+            lookup_table = relation["lookup_table"]
+            processed_column = relation["processed_column"]
+            join_table = relation["join_table"]
+            join_column = relation["join_column"]
+            id_column = relation.get("id_column")
+
+            existing_ids: list[int] = []
+            try:
+                cur_existing = conn.execute(
+                    f"SELECT {join_column} FROM {join_table} "
+                    "WHERE processed_game_id = ? ORDER BY rowid",
+                    (game_id,),
+                )
+            except sqlite3.OperationalError:
+                existing_ids = []
+            else:
+                for existing_row in cur_existing.fetchall():
+                    coerced = _coerce_int(row_value(existing_row, join_column, 0))
+                    if coerced is None:
+                        continue
+                    existing_ids.append(coerced)
+
+            candidate_ids: list[int] = list(existing_ids)
+
+            if not candidate_ids and id_column in row_dict:
+                candidate_ids.extend(decode_lookup_id_list(row_dict.get(id_column)))
+
+            if not candidate_ids:
+                raw_value = row_dict.get(processed_column)
+                names = parse_iterable(raw_value)
+                seen_names: set[str] = set()
+                for name in names:
+                    normalized = normalize_lookup_name(name)
+                    if not normalized:
+                        continue
+                    fingerprint = normalized.casefold()
+                    if fingerprint in seen_names:
+                        continue
+                    seen_names.add(fingerprint)
+                    lookup_id = get_or_create_lookup_id(conn, lookup_table, normalized)
+                    if lookup_id is None:
+                        continue
+                    candidate_ids.append(int(lookup_id))
+
+            deduped_ids: list[int] = []
+            seen_ids: set[int] = set()
+            for value in candidate_ids:
+                coerced = _coerce_int(value)
+                if coerced is None or coerced in seen_ids:
+                    continue
+                seen_ids.add(coerced)
+                deduped_ids.append(coerced)
+
+            if existing_ids and deduped_ids == existing_ids:
+                continue
+
+            _replace_relations(conn, join_table, join_column, game_id, deduped_ids)
+

--- a/processed/catalog.py
+++ b/processed/catalog.py
@@ -1,0 +1,125 @@
+"""Catalog state management for processed games navigation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import logging
+from typing import Callable, Iterable, Mapping
+
+import pandas as pd
+
+from . import navigator as processed_navigator
+
+
+@dataclass
+class CatalogState:
+    """Track the in-memory games catalog and navigator integration."""
+
+    navigator_factory: Callable[[], processed_navigator.GameNavigator]
+    category_labels: Mapping[int, str] | None = None
+    logger: logging.Logger | None = None
+
+    games_df: pd.DataFrame = field(default_factory=pd.DataFrame)
+    total_games: int = 0
+    categories_list: list[str] = field(default_factory=list)
+    platforms_list: list[str] = field(default_factory=list)
+    _category_values: set[str] = field(default_factory=set)
+    _navigator: processed_navigator.GameNavigator | None = None
+
+    def set_games_dataframe(
+        self,
+        df: pd.DataFrame | None,
+        *,
+        rebuild_metadata: bool = True,
+        rebuild_navigator: bool = True,
+    ) -> None:
+        """Replace the cached games dataframe and refresh derived state."""
+
+        if df is None:
+            df = pd.DataFrame()
+        self.games_df = df
+        self.total_games = len(df)
+
+        if rebuild_metadata:
+            self._rebuild_metadata(df)
+
+        if rebuild_navigator:
+            self.ensure_navigator().set_games_df(df, rebuild_state=True)
+        else:
+            navigator = self._navigator
+            if navigator is not None:
+                navigator.set_games_df(df, rebuild_state=False)
+
+    def ensure_navigator(self) -> processed_navigator.GameNavigator:
+        """Return the shared navigator instance, creating it if needed."""
+
+        if self._navigator is None:
+            self._navigator = self.navigator_factory()
+            try:
+                self._navigator.set_games_df(self.games_df, rebuild_state=True)
+            except Exception:
+                if self.logger:
+                    self.logger.exception("Failed to initialize navigator state")
+                raise
+        return self._navigator
+
+    def ensure_navigator_dataframe(
+        self, *, rebuild_state: bool = False
+    ) -> processed_navigator.GameNavigator:
+        """Synchronize the navigator with the current dataframe."""
+
+        navigator = self.ensure_navigator()
+        df = self.games_df if self.games_df is not None else pd.DataFrame()
+        if navigator.games_df is not df or navigator.total != len(df):
+            navigator.set_games_df(df, rebuild_state=rebuild_state)
+        return navigator
+
+    def reset_source_index_cache(self) -> None:
+        self.ensure_navigator().reset_source_index_cache()
+
+    def get_source_index_for_position(self, position: int) -> str:
+        navigator = self.ensure_navigator_dataframe(rebuild_state=False)
+        return navigator.get_source_index_for_position(position)
+
+    def get_position_for_source_index(self, value: object) -> int | None:
+        navigator = self.ensure_navigator_dataframe(rebuild_state=False)
+        return navigator.get_position_for_source_index(value)
+
+    def get_category_values(self) -> set[str]:
+        return set(self._category_values)
+
+    def get_categories(self) -> list[str]:
+        return list(self.categories_list)
+
+    def get_platforms(self) -> list[str]:
+        return list(self.platforms_list)
+
+    def set_navigator(self, navigator: processed_navigator.GameNavigator | None) -> None:
+        self._navigator = navigator
+
+    def _rebuild_metadata(self, df: pd.DataFrame) -> None:
+        category_values: set[str] = set()
+        if not df.empty and 'Category' in df.columns:
+            for raw_category in df['Category'].dropna():
+                text = str(raw_category).strip()
+                if text:
+                    category_values.add(text)
+        if self.category_labels:
+            category_values.update(
+                label for label in self.category_labels.values() if label
+            )
+        self._category_values = category_values
+        self.categories_list = sorted(category_values, key=str.casefold)
+
+        platform_values: set[str] = set()
+        if not df.empty and 'Platforms' in df.columns:
+            for raw_platforms in df['Platforms'].dropna():
+                for entry in str(raw_platforms).split(','):
+                    text = entry.strip()
+                    if text:
+                        platform_values.add(text)
+        self.platforms_list = sorted(platform_values, key=str.casefold)
+
+
+__all__ = ["CatalogState"]
+

--- a/processed/navigator.py
+++ b/processed/navigator.py
@@ -1,5 +1,350 @@
 """Navigation helpers for iterating through processed games."""
-
 from __future__ import annotations
 
-# TODO: Implement navigation state management and skip-queue handling.
+import json
+import logging
+from threading import Lock
+from typing import Any, Callable
+
+import pandas as pd
+import sqlite3
+
+
+class GameNavigator:
+    """Thread-safe helper to navigate game list and track progress."""
+
+    def __init__(
+        self,
+        *,
+        db_lock: Lock,
+        get_db: Callable[[], sqlite3.Connection],
+        is_processed_game_done: Callable[[Any, Any], bool],
+        logger: logging.Logger | None = None,
+    ) -> None:
+        self.lock = Lock()
+        self._cache_lock = Lock()
+        self._db_lock = db_lock
+        self._get_db = get_db
+        self._is_processed_game_done = is_processed_game_done
+        self._logger = logger or logging.getLogger(__name__)
+
+        self._games_df: pd.DataFrame = pd.DataFrame()
+        self.total: int = 0
+        self.current_index: int = 0
+        self.seq_index: int = 1
+        self.processed_total: int = 0
+        self.skip_queue: list[dict[str, int]] = []
+
+        self._source_index_by_position: dict[int, str] | None = None
+        self._position_by_source_index: dict[str, int] | None = None
+        self._source_index_cache_df_id: int | None = None
+
+    @property
+    def games_df(self) -> pd.DataFrame:
+        """Return the currently loaded games dataframe."""
+
+        return self._games_df
+
+    def set_games_df(
+        self,
+        games_df: pd.DataFrame | None,
+        *,
+        rebuild_state: bool = True,
+    ) -> None:
+        """Assign a new games dataframe and optionally rebuild persisted state."""
+
+        if games_df is None:
+            games_df = pd.DataFrame()
+        self._games_df = games_df
+        self.total = len(games_df)
+        self.reset_source_index_cache()
+        if rebuild_state:
+            self._load_initial()
+        else:
+            if self.current_index > self.total:
+                self.current_index = self.total
+            if self.seq_index < 1:
+                self.seq_index = 1
+            if self.processed_total > self.total:
+                self.processed_total = self.total
+
+    @staticmethod
+    def canonical_source_index(value: Any) -> str | None:
+        """Normalize ``Source Index`` values to a consistent string representation."""
+
+        if value is None:
+            return None
+        text = str(value).strip()
+        if not text:
+            return None
+        try:
+            return str(int(text))
+        except (TypeError, ValueError):
+            return text
+
+    def reset_source_index_cache(self) -> None:
+        """Clear cached mappings between navigator positions and ``Source Index`` values."""
+
+        with self._cache_lock:
+            self._source_index_by_position = None
+            self._position_by_source_index = None
+            self._source_index_cache_df_id = None
+
+    def _ensure_source_index_cache(self) -> tuple[dict[int, str], dict[str, int]]:
+        """Build and return cached lookup tables for ``Source Index`` values."""
+
+        df = self._games_df
+        if df is None:
+            raise RuntimeError('games_df is not loaded')
+
+        with self._cache_lock:
+            df_id = id(df)
+            if (
+                self._source_index_by_position is None
+                or self._position_by_source_index is None
+                or self._source_index_cache_df_id != df_id
+                or len(self._source_index_by_position) != len(df)
+            ):
+                mapping: dict[int, str] = {}
+                reverse: dict[str, int] = {}
+                if len(df) > 0:
+                    source_values: list[Any] | None = None
+                    if 'Source Index' in df.columns:
+                        source_values = df['Source Index'].tolist()
+                    for position in range(len(df)):
+                        if source_values is not None and position < len(source_values):
+                            raw_value = source_values[position]
+                        else:
+                            raw_value = position
+                        canonical = self.canonical_source_index(raw_value)
+                        if canonical is None:
+                            canonical = str(position)
+                        mapping[position] = canonical
+                        reverse.setdefault(canonical, position)
+                self._source_index_by_position = mapping
+                self._position_by_source_index = reverse
+                self._source_index_cache_df_id = df_id
+
+            return self._source_index_by_position, self._position_by_source_index
+
+    def get_source_index_for_position(self, position: int) -> str:
+        """Return the normalized ``Source Index`` string for a DataFrame position."""
+
+        if position < 0:
+            raise IndexError('invalid index')
+        mapping, _ = self._ensure_source_index_cache()
+        try:
+            return mapping[position]
+        except KeyError as exc:
+            raise IndexError('invalid index') from exc
+
+    def get_position_for_source_index(self, value: Any) -> int | None:
+        """Resolve a ``Source Index`` value back to its DataFrame position."""
+
+        canonical = self.canonical_source_index(value)
+        if canonical is None:
+            return None
+        mapping, reverse = self._ensure_source_index_cache()
+        position = reverse.get(canonical)
+        if position is not None:
+            return position
+        try:
+            fallback = int(canonical)
+        except (TypeError, ValueError):
+            return None
+        if fallback < 0:
+            return None
+        return fallback
+
+    def _load_initial(self) -> None:
+        with self._db_lock:
+            conn = self._get_db()
+            cur = conn.execute(
+                'SELECT current_index, seq_index, skip_queue FROM navigator_state WHERE id=1'
+            )
+            state_row = cur.fetchone()
+            cur = conn.execute(
+                'SELECT "Source Index", "ID", "Summary", "Cover Path" FROM processed_games'
+            )
+            rows = cur.fetchall()
+        processed: set[int] = set()
+        max_seq = 0
+        for row in rows:
+            position = self.get_position_for_source_index(row['Source Index'])
+            if position is not None and 0 <= position < self.total:
+                try:
+                    summary_value = row['Summary']
+                except (KeyError, IndexError, TypeError):
+                    summary_value = None
+                try:
+                    cover_value = row['Cover Path']
+                except (KeyError, IndexError, TypeError):
+                    cover_value = None
+                if self._is_processed_game_done(summary_value, cover_value):
+                    processed.add(position)
+            try:
+                row_id = int(row['ID'])
+            except (TypeError, ValueError):
+                row_id = None
+            if row_id is not None and row_id > max_seq:
+                max_seq = row_id
+        next_index = next((i for i in range(self.total) if i not in processed), self.total)
+        expected_seq = max_seq + 1 if max_seq > 0 else 1
+        self.processed_total = len(processed)
+        if state_row is not None:
+            try:
+                file_current = int(state_row['current_index'])
+                file_seq = int(state_row['seq_index'])
+                file_skip = json.loads(state_row['skip_queue'] or '[]')
+                if file_current == next_index and file_seq == expected_seq:
+                    self.current_index = file_current
+                    self.seq_index = file_seq
+                    self.skip_queue = file_skip
+                    self._logger.debug(
+                        "Loaded progress: current_index=%s seq_index=%s skip_queue=%s",
+                        self.current_index,
+                        self.seq_index,
+                        self.skip_queue,
+                    )
+                    return
+                self._logger.warning("Navigator state out of sync with database; rebuilding")
+            except Exception as exc:  # pragma: no cover - defensive logging
+                self._logger.warning("Failed to load navigator state: %s", exc)
+        self.current_index = next_index
+        self.seq_index = expected_seq
+        self.skip_queue = []
+        self._logger.debug(
+            "Loaded progress: current_index=%s seq_index=%s skip_queue=%s",
+            self.current_index,
+            self.seq_index,
+            self.skip_queue,
+        )
+        self._save()
+
+    def _load(self) -> None:
+        with self._db_lock:
+            conn = self._get_db()
+            cur = conn.execute(
+                'SELECT current_index, seq_index, skip_queue FROM navigator_state WHERE id=1'
+            )
+            state_row = cur.fetchone()
+            cur = conn.execute(
+                'SELECT "Summary", "Cover Path" FROM processed_games'
+            )
+            rows = cur.fetchall()
+        processed_total = 0
+        for row in rows:
+            try:
+                summary_value = row['Summary']
+            except (KeyError, IndexError, TypeError):
+                summary_value = None
+            try:
+                cover_value = row['Cover Path']
+            except (KeyError, IndexError, TypeError):
+                cover_value = None
+            if self._is_processed_game_done(summary_value, cover_value):
+                processed_total += 1
+        self.processed_total = max(processed_total, 0)
+        if state_row is not None:
+            try:
+                self.current_index = int(state_row['current_index'])
+                self.seq_index = int(state_row['seq_index'])
+                self.skip_queue = json.loads(state_row['skip_queue'] or '[]')
+                self._logger.debug(
+                    "Loaded progress: current_index=%s seq_index=%s skip_queue=%s",
+                    self.current_index,
+                    self.seq_index,
+                    self.skip_queue,
+                )
+                return
+            except Exception as exc:  # pragma: no cover - defensive logging
+                self._logger.warning("Failed to load navigator state: %s", exc)
+        self._load_initial()
+
+    def _save(self) -> None:
+        try:
+            with self._db_lock:
+                conn = self._get_db()
+                conn.execute(
+                    'REPLACE INTO navigator_state (id, current_index, seq_index, skip_queue) VALUES (1, ?, ?, ?)',
+                    (
+                        self.current_index,
+                        self.seq_index,
+                        json.dumps(self.skip_queue),
+                    ),
+                )
+                conn.commit()
+        except Exception as exc:  # pragma: no cover - defensive logging
+            self._logger.warning("Failed to save navigator state: %s", exc)
+
+    def _process_skip_queue(self) -> None:
+        self._logger.debug(
+            "Processing skip queue: index=%s queue=%s",
+            self.current_index,
+            self.skip_queue,
+        )
+        for item in self.skip_queue:
+            item['countdown'] -= 1
+        for i, item in enumerate(self.skip_queue):
+            if item['countdown'] <= 0:
+                old_index = self.current_index
+                self.current_index = item['index']
+                del self.skip_queue[i]
+                self._logger.debug(
+                    "Skip queue hit: index from %s to %s",
+                    old_index,
+                    self.current_index,
+                )
+                break
+        self._logger.debug(
+            "After processing skip queue: index=%s queue=%s",
+            self.current_index,
+            self.skip_queue,
+        )
+
+    def next(self) -> int:
+        with self.lock:
+            self._load()
+            before = self.current_index
+            self._logger.debug("next() before skip queue: index=%s", before)
+            self._process_skip_queue()
+            self._logger.debug("next() after skip queue: index=%s", self.current_index)
+            if self.current_index < self.total:
+                self.current_index += 1
+            self._logger.debug("next() after increment: index=%s", self.current_index)
+            self._save()
+            return self.current_index
+
+    def back(self) -> int:
+        with self.lock:
+            self._load()
+            before = self.current_index
+            self._logger.debug("back() before skip queue: index=%s", before)
+            self._process_skip_queue()
+            self._logger.debug("back() after skip queue: index=%s", self.current_index)
+            if self.current_index > 0:
+                self.current_index -= 1
+            self._logger.debug("back() after decrement: index=%s", self.current_index)
+            self._save()
+            return self.current_index
+
+    def current(self) -> int:
+        with self.lock:
+            self._load()
+            return self.current_index
+
+    def skip(self, index: int) -> None:
+        with self.lock:
+            self._load()
+            self.skip_queue = [s for s in self.skip_queue if s['index'] != index]
+            self.skip_queue.append({'index': index, 'countdown': 30})
+            if index == self.current_index:
+                self.current_index += 1
+            self._save()
+
+    def set_index(self, index: int) -> None:
+        with self.lock:
+            self._load()
+            if 0 <= index <= self.total:
+                self.current_index = index
+            self._save()

--- a/routes/web.py
+++ b/routes/web.py
@@ -1,8 +1,83 @@
 """HTML-facing Flask routes and authentication flows."""
-
 from __future__ import annotations
 
-from flask import Blueprint
+from typing import Any, Callable, Mapping
 
-# TODO: Register HTML routes, authentication handlers, and template context setup.
+from flask import (
+    Blueprint,
+    redirect,
+    render_template,
+    request,
+    session,
+    url_for,
+)
+
 web_blueprint = Blueprint("web", __name__)
+
+_context: dict[str, Any] = {}
+
+
+def configure(context: Mapping[str, Any]) -> None:
+    """Provide shared state required by the HTML routes."""
+    _context.update(context)
+
+
+def _ctx(key: str) -> Any:
+    if key not in _context:
+        raise RuntimeError(f"web routes missing context value: {key}")
+    return _context[key]
+
+
+def _get_total_games() -> int:
+    getter: Callable[[], int] = _ctx("get_total_games")
+    return getter()
+
+
+def _get_categories() -> list[str]:
+    getter: Callable[[], list[str]] = _ctx("get_categories")
+    return getter()
+
+
+def _get_platforms() -> list[str]:
+    getter: Callable[[], list[str]] = _ctx("get_platforms")
+    return getter()
+
+
+def _get_app_password() -> str:
+    return _ctx("app_password")
+
+
+@web_blueprint.before_app_request
+def require_login():
+    if request.endpoint in ("web.login", "static"):
+        return None
+    if session.get("authenticated"):
+        return None
+    return redirect(url_for("web.login"))
+
+
+@web_blueprint.route("/login", methods=["GET", "POST"])
+def login():
+    error = None
+    if request.method == "POST":
+        if request.form.get("password") == _get_app_password():
+            session["authenticated"] = True
+            return redirect(url_for("web.index"))
+        error = "Invalid password"
+    return render_template("login.html", error=error)
+
+
+@web_blueprint.route("/logout")
+def logout():
+    session.clear()
+    return redirect(url_for("web.login"))
+
+
+@web_blueprint.route("/")
+def index():
+    return render_template(
+        "index.html",
+        total=_get_total_games(),
+        categories=_get_categories(),
+        platforms=_get_platforms(),
+    )

--- a/templates/index.html
+++ b/templates/index.html
@@ -16,12 +16,12 @@
     <div id="toast" role="status" aria-live="polite"></div>
     <header class="app-topbar" aria-label="Primary navigation">
         <div class="topbar-content">
-            <a class="topbar-brand" href="{{ url_for('index') }}">Game Editor</a>
+            <a class="topbar-brand" href="{{ url_for('web.index') }}">Game Editor</a>
             <nav class="topbar-nav" aria-label="Global">
-                <a class="topbar-link is-active" href="{{ url_for('index') }}">Editor</a>
+                <a class="topbar-link is-active" href="{{ url_for('web.index') }}">Editor</a>
                 <a class="topbar-link" href="{{ url_for('updates.updates_page') }}">IGDB Updates</a>
                 <a class="topbar-link" href="{{ url_for('lookups.lookups_page') }}">Lookups</a>
-                <a class="topbar-link" href="{{ url_for('logout') }}">Logout</a>
+                <a class="topbar-link" href="{{ url_for('web.logout') }}">Logout</a>
             </nav>
         </div>
     </header>

--- a/templates/lookups.html
+++ b/templates/lookups.html
@@ -12,12 +12,12 @@
     <div id="toast" role="status" aria-live="polite"></div>
     <header class="app-topbar" aria-label="Primary navigation">
         <div class="topbar-content">
-            <a class="topbar-brand" href="{{ url_for('index') }}">Game Editor</a>
+            <a class="topbar-brand" href="{{ url_for('web.index') }}">Game Editor</a>
             <nav class="topbar-nav" aria-label="Global">
-                <a class="topbar-link" href="{{ url_for('index') }}">Editor</a>
+                <a class="topbar-link" href="{{ url_for('web.index') }}">Editor</a>
                 <a class="topbar-link" href="{{ url_for('updates.updates_page') }}">IGDB Updates</a>
                 <a class="topbar-link is-active" href="{{ url_for('lookups.lookups_page') }}">Lookups</a>
-                <a class="topbar-link" href="{{ url_for('logout') }}">Logout</a>
+                <a class="topbar-link" href="{{ url_for('web.logout') }}">Logout</a>
             </nav>
         </div>
     </header>

--- a/templates/updates.html
+++ b/templates/updates.html
@@ -12,12 +12,12 @@
     <div id="toast" role="status" aria-live="polite"></div>
     <header class="app-topbar" aria-label="Primary navigation">
         <div class="topbar-content">
-            <a class="topbar-brand" href="{{ url_for('index') }}">Game Editor</a>
+            <a class="topbar-brand" href="{{ url_for('web.index') }}">Game Editor</a>
             <nav class="topbar-nav" aria-label="Global">
-                <a class="topbar-link" href="{{ url_for('index') }}">Editor</a>
+                <a class="topbar-link" href="{{ url_for('web.index') }}">Editor</a>
                 <a class="topbar-link is-active" href="{{ url_for('updates.updates_page') }}">IGDB Updates</a>
                 <a class="topbar-link" href="{{ url_for('lookups.lookups_page') }}">Lookups</a>
-                <a class="topbar-link" href="{{ url_for('logout') }}">Logout</a>
+                <a class="topbar-link" href="{{ url_for('web.logout') }}">Logout</a>
             </nav>
         </div>
     </header>
@@ -182,7 +182,7 @@
     </div>
     <script>
         window.updatesConfig = {
-            editBaseUrl: {{ url_for('index')|tojson }},
+            editBaseUrl: {{ url_for('web.index')|tojson }},
             updatesUrl: {{ url_for('updates.api_updates_list')|tojson }},
             refreshUrl: {{ url_for('updates.api_updates_refresh')|tojson }},
             cacheRefreshUrl: {{ url_for('updates.api_igdb_cache_refresh')|tojson }},

--- a/tests/test_backfill_igdb_ids.py
+++ b/tests/test_backfill_igdb_ids.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-from tests.app_helpers import load_app
+from tests.app_helpers import load_app, set_games_dataframe
 
 
 def test_backfill_igdb_ids_skips_rows_with_summary(tmp_path):
@@ -18,15 +18,15 @@ def test_backfill_igdb_ids_skips_rows_with_summary(tmp_path):
                 ],
             )
 
-    app_module.games_df = pd.DataFrame(
-        [
-            {'Source Index': '0', 'id': 101},
-            {'Source Index': '1', 'id': 202},
-        ]
+    set_games_dataframe(
+        app_module,
+        pd.DataFrame(
+            [
+                {'Source Index': '0', 'id': 101},
+                {'Source Index': '1', 'id': 202},
+            ]
+        ),
     )
-    app_module.total_games = len(app_module.games_df)
-    if hasattr(app_module, 'reset_source_index_cache'):
-        app_module.reset_source_index_cache()
 
     app_module.backfill_igdb_ids()
 

--- a/tests/test_navigator_state.py
+++ b/tests/test_navigator_state.py
@@ -178,7 +178,8 @@ def test_save_with_outdated_index_keeps_next_row_intact(tmp_path):
     with client.session_transaction() as sess:
         sess['authenticated'] = True
     # Simulate navigator moving to the next index while still editing index 0
-    app.navigator.current_index += 1  # now at 1
+    navigator = app._ensure_navigator_dataframe(rebuild_state=False)
+    navigator.current_index += 1  # now at 1
     resp = client.post(
         '/api/save',
         json={'index': 0, 'id': '1', 'fields': {'Name': 'changed'}},

--- a/tests/test_seed_processed_games.py
+++ b/tests/test_seed_processed_games.py
@@ -1,6 +1,8 @@
 import pandas as pd
 
-from tests.app_helpers import load_app
+import pandas as pd
+
+from tests.app_helpers import load_app, set_games_dataframe
 
 
 def test_seed_processed_games_respects_existing_keys(tmp_path):
@@ -17,14 +19,16 @@ def test_seed_processed_games_respects_existing_keys(tmp_path):
                 ],
             )
 
-    app_module.games_df = pd.DataFrame(
-        [
-            {'Source Index': 'A-123', 'Name': 'Alpha Updated'},
-            {'Source Index': 'B-456', 'Name': 'Beta'},
-            {'Source Index': None, 'Name': 'Should Skip'},
-        ]
+    set_games_dataframe(
+        app_module,
+        pd.DataFrame(
+            [
+                {'Source Index': 'A-123', 'Name': 'Alpha Updated'},
+                {'Source Index': 'B-456', 'Name': 'Beta'},
+                {'Source Index': None, 'Name': 'Should Skip'},
+            ]
+        ),
     )
-    app_module.total_games = len(app_module.games_df)
 
     app_module.seed_processed_games_from_source()
 
@@ -57,12 +61,12 @@ def test_seed_processed_games_skips_rows_with_summary(tmp_path):
                 ),
             )
 
-    app_module.games_df = pd.DataFrame([
-        {'Source Index': '00123', 'Name': 'Updated From IGDB'},
-    ])
-    app_module.total_games = len(app_module.games_df)
-    if hasattr(app_module, 'reset_source_index_cache'):
-        app_module.reset_source_index_cache()
+    set_games_dataframe(
+        app_module,
+        pd.DataFrame([
+            {'Source Index': '00123', 'Name': 'Updated From IGDB'},
+        ]),
+    )
 
     app_module.seed_processed_games_from_source()
 

--- a/web/app_factory.py
+++ b/web/app_factory.py
@@ -1,7 +1,24 @@
 """Flask application factory and service client initialization."""
-
 from __future__ import annotations
+
+from typing import Callable
 
 from flask import Flask
 
-# TODO: Provide factory helpers to configure the Flask app and integrate services.
+
+def create_app(
+    flask_app: Flask | None = None,
+    *,
+    configure_blueprints: Callable[[Flask], None] | None = None,
+) -> Flask:
+    """Return a configured Flask application instance."""
+    if flask_app is None or configure_blueprints is None:
+        from app import app as default_app, configure_blueprints as default_configure
+
+        if flask_app is None:
+            flask_app = default_app
+        if configure_blueprints is None:
+            configure_blueprints = default_configure
+
+    configure_blueprints(flask_app)
+    return flask_app


### PR DESCRIPTION
## Summary
- add a `processed.catalog.CatalogState` helper to centralize the in-memory games dataframe, metadata lists, and navigator lifecycle management
- refactor `app.py` to route all games dataframe and navigator interactions through the catalog state and expose the new getters to blueprints
- update test helpers and suites to use the catalog state API instead of mutating module globals directly

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d4a699c93c8333b96f39af3136dbeb