### PR TITLE
Add navigator completion percentage tracking

### DIFF
--- a/processed/navigator.py
+++ b/processed/navigator.py
@@ -333,6 +333,16 @@ class GameNavigator:
             self._load()
             return self.current_index
 
+    def completion_percentage(self) -> float:
+        """Return the percentage of games that have been processed."""
+
+        with self.lock:
+            self._load()
+            if self.total <= 0:
+                return 0.0
+            completed = min(max(self.processed_total, 0), self.total)
+            return (completed / self.total) * 100.0
+
     def skip(self, index: int) -> None:
         with self.lock:
             self._load()

--- a/routes/games.py
+++ b/routes/games.py
@@ -50,12 +50,19 @@ def api_game():
     try:
         index = navigator.current()
         if index >= _get_total_games():
-            return jsonify({'done': True, 'message': 'Todos os jogos foram processados.'})
+            return jsonify(
+                {
+                    'done': True,
+                    'message': 'Todos os jogos foram processados.',
+                    'completion': navigator.completion_percentage(),
+                }
+            )
         data = _ctx('build_game_payload')(
             index,
             navigator.seq_index,
             navigator.processed_total + 1,
         )
+        data['completion'] = navigator.completion_percentage()
         return jsonify(data)
     except Exception as exc:  # pragma: no cover - defensive logging
         current_app.logger.exception("api_game failed")

--- a/tests/test_navigator_state.py
+++ b/tests/test_navigator_state.py
@@ -1,4 +1,5 @@
 import json
+import math
 import sqlite3
 
 from tests.app_helpers import load_app
@@ -193,6 +194,13 @@ def test_save_with_outdated_index_keeps_next_row_intact(tmp_path):
         )
         row = cur.fetchone()
     assert row['Name'] == 'original'
+
+
+def test_completion_percentage(tmp_path):
+    app = load_app(tmp_path)
+    populate_db(app, 5)
+    nav = app.GameNavigator(10)
+    assert math.isclose(nav.completion_percentage(), 50.0)
 
 
 def test_out_of_order_ids_are_normalized(tmp_path):


### PR DESCRIPTION
## Summary
- add a completion_percentage helper to the navigator that persists navigation state
- expose completion data through the /api/game endpoint responses
- cover the new navigator behaviour with an additional test

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5bb3598f48333b0d4b46b066695e4