### PR TITLE
Revise update UI elements

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -382,6 +382,38 @@ body.modal-open {
   justify-content: center;
 }
 
+.search-field {
+  display: inline-flex;
+  align-items: stretch;
+}
+
+.search-input {
+  flex: 1;
+  width: 100%;
+  padding: 11px 18px;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: var(--color-surface-elevated);
+  color: var(--color-text);
+  font-size: 0.95rem;
+  transition: border-color 120ms ease, box-shadow 120ms ease;
+}
+
+.search-input::placeholder {
+  color: rgba(226, 232, 240, 0.5);
+}
+
+.search-input:focus {
+  outline: none;
+  border-color: rgba(255, 255, 255, 0.36);
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.24);
+}
+
+.search-input:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
 .btn-icon .material-symbols-rounded {
   font-size: 22px;
   line-height: 1;
@@ -760,28 +792,7 @@ textarea {
 }
 
 .updates-search {
-  display: inline-flex;
-  align-items: center;
-  gap: 10px;
-  padding: 10px 18px;
-  border-radius: 12px;
-  border: 1px solid var(--color-border);
-  background: var(--color-surface-elevated);
-  color: var(--color-muted);
   min-width: 260px;
-}
-
-.updates-search input {
-  border: none;
-  background: transparent;
-  color: var(--color-text);
-  font-size: 0.95rem;
-  outline: none;
-  width: 100%;
-}
-
-.updates-search input::placeholder {
-  color: rgba(226, 232, 240, 0.5);
 }
 
 .updates-summary {
@@ -1023,28 +1034,7 @@ textarea {
 }
 
 .lookups-search {
-  display: inline-flex;
-  align-items: center;
-  gap: 10px;
-  padding: 10px 18px;
-  border-radius: 12px;
-  border: 1px solid var(--color-border);
-  background: var(--color-surface-elevated);
-  color: var(--color-muted);
   min-width: 240px;
-}
-
-.lookups-search input {
-  border: none;
-  background: transparent;
-  color: var(--color-text);
-  font-size: 0.95rem;
-  outline: none;
-  width: 100%;
-}
-
-.lookups-search input::placeholder {
-  color: rgba(226, 232, 240, 0.5);
 }
 
 .lookups-summary {

--- a/static/updates.js
+++ b/static/updates.js
@@ -69,9 +69,6 @@
     const toast = document.getElementById('toast');
     let toastTimer = null;
     let lastFocusedElement = null;
-    let fixHideTimer = null;
-    let refreshHideTimer = null;
-    let dedupeHideTimer = null;
 
     function showToast(message, type = 'success') {
         if (!toast) {
@@ -711,20 +708,24 @@
                 state.fixingNames = active;
                 setFixButtonLoading(active);
                 if (active) {
-                    clearTimeout(fixHideTimer);
                     setFixProgressVisible(true);
+                    updateFixProgress(job.progress_current || 0, job.progress_total || 0);
+                } else {
+                    updateFixProgress(0, 0);
+                    setFixProgressVisible(false);
                 }
-                updateFixProgress(job.progress_current || 0, job.progress_total || 0);
                 break;
             }
             case JOB_TYPES.refresh: {
                 state.refreshing = active;
                 setRefreshButtonLoading(active);
                 if (active) {
-                    clearTimeout(refreshHideTimer);
                     setRefreshProgressVisible(true);
+                    updateRefreshProgress(job.progress_current || 0, job.progress_total || 0);
+                } else {
+                    updateRefreshProgress(0, 0);
+                    setRefreshProgressVisible(false);
                 }
-                updateRefreshProgress(job.progress_current || 0, job.progress_total || 0);
                 if (elements.statusLabel && job.message) {
                     elements.statusLabel.textContent = job.message;
                 }
@@ -734,10 +735,12 @@
                 state.deduping = active;
                 setDedupeButtonLoading(active);
                 if (active) {
-                    clearTimeout(dedupeHideTimer);
                     setDedupeProgressVisible(true);
+                    updateDedupeProgress(job.progress_current || 0, job.progress_total || 0);
+                } else {
+                    updateDedupeProgress(0, 0);
+                    setDedupeProgressVisible(false);
                 }
-                updateDedupeProgress(job.progress_current || 0, job.progress_total || 0);
                 break;
             }
             default:
@@ -757,11 +760,8 @@
         if (type === JOB_TYPES.fix) {
             state.fixingNames = false;
             setFixButtonLoading(false);
-            clearTimeout(fixHideTimer);
-            fixHideTimer = window.setTimeout(() => {
-                updateFixProgress(0, 0);
-                setFixProgressVisible(false);
-            }, 1200);
+            updateFixProgress(0, 0);
+            setFixProgressVisible(false);
             if (status === 'success') {
                 state.detailCache.clear();
                 loadUpdates();
@@ -769,11 +769,8 @@
         } else if (type === JOB_TYPES.refresh) {
             state.refreshing = false;
             setRefreshButtonLoading(false);
-            clearTimeout(refreshHideTimer);
-            refreshHideTimer = window.setTimeout(() => {
-                updateRefreshProgress(0, 0);
-                setRefreshProgressVisible(false);
-            }, 1200);
+            updateRefreshProgress(0, 0);
+            setRefreshProgressVisible(false);
             if (status === 'success') {
                 state.detailCache.clear();
                 loadUpdates();
@@ -781,11 +778,8 @@
         } else if (type === JOB_TYPES.dedupe) {
             state.deduping = false;
             setDedupeButtonLoading(false);
-            clearTimeout(dedupeHideTimer);
-            dedupeHideTimer = window.setTimeout(() => {
-                updateDedupeProgress(0, 0);
-                setDedupeProgressVisible(false);
-            }, 1200);
+            updateDedupeProgress(0, 0);
+            setDedupeProgressVisible(false);
             if (status === 'success' && Number(result.removed) > 0) {
                 state.detailCache.clear();
                 loadUpdates();
@@ -889,7 +883,6 @@
             return;
         }
         state.fixingNames = true;
-        clearTimeout(fixHideTimer);
         setFixButtonLoading(true);
         setFixProgressVisible(true);
         updateFixProgress(0, 0);
@@ -901,10 +894,8 @@
             showToast(error.message, 'warning');
             state.fixingNames = false;
             setFixButtonLoading(false);
-            fixHideTimer = window.setTimeout(() => {
-                updateFixProgress(0, 0);
-                setFixProgressVisible(false);
-            }, 1200);
+            updateFixProgress(0, 0);
+            setFixProgressVisible(false);
         } finally {
             // Loading state will be reset when the job completes or fails.
         }
@@ -920,7 +911,6 @@
         }
         state.deduping = true;
         setDedupeButtonLoading(true);
-        clearTimeout(dedupeHideTimer);
         setDedupeProgressVisible(true);
         updateDedupeProgress(0, 0);
         try {
@@ -930,12 +920,9 @@
             console.error(error);
             showToast(error.message, 'warning');
             state.deduping = false;
-            state.deduping = false;
             setDedupeButtonLoading(false);
-            dedupeHideTimer = window.setTimeout(() => {
-                updateDedupeProgress(0, 0);
-                setDedupeProgressVisible(false);
-            }, 1200);
+            updateDedupeProgress(0, 0);
+            setDedupeProgressVisible(false);
         }
     }
 
@@ -1140,7 +1127,6 @@
             return;
         }
         state.refreshing = true;
-        clearTimeout(refreshHideTimer);
         setRefreshProgressVisible(true);
         updateRefreshProgress(0, 0);
         setRefreshButtonLoading(true);
@@ -1152,10 +1138,8 @@
             showToast(error.message, 'warning');
             state.refreshing = false;
             setRefreshButtonLoading(false);
-            refreshHideTimer = window.setTimeout(() => {
-                updateRefreshProgress(0, 0);
-                setRefreshProgressVisible(false);
-            }, 1200);
+            updateRefreshProgress(0, 0);
+            setRefreshProgressVisible(false);
         } finally {
             // Button state resets when job completes.
         }

--- a/templates/index.html
+++ b/templates/index.html
@@ -19,7 +19,7 @@
             <a class="topbar-brand" href="{{ url_for('web.index') }}">Game Editor</a>
             <nav class="topbar-nav" aria-label="Global">
                 <a class="topbar-link is-active" href="{{ url_for('web.index') }}">Editor</a>
-                <a class="topbar-link" href="{{ url_for('updates.updates_page') }}">IGDB Updates</a>
+                <a class="topbar-link" href="{{ url_for('updates.updates_page') }}">Update</a>
                 <a class="topbar-link" href="{{ url_for('lookups.lookups_page') }}">Lookups</a>
                 <a class="topbar-link" href="{{ url_for('web.logout') }}">Logout</a>
             </nav>

--- a/templates/lookups.html
+++ b/templates/lookups.html
@@ -15,7 +15,7 @@
             <a class="topbar-brand" href="{{ url_for('web.index') }}">Game Editor</a>
             <nav class="topbar-nav" aria-label="Global">
                 <a class="topbar-link" href="{{ url_for('web.index') }}">Editor</a>
-                <a class="topbar-link" href="{{ url_for('updates.updates_page') }}">IGDB Updates</a>
+                <a class="topbar-link" href="{{ url_for('updates.updates_page') }}">Update</a>
                 <a class="topbar-link is-active" href="{{ url_for('lookups.lookups_page') }}">Lookups</a>
                 <a class="topbar-link" href="{{ url_for('web.logout') }}">Logout</a>
             </nav>
@@ -36,14 +36,14 @@
                         {% endfor %}
                     </select>
                 </label>
-                <label class="lookups-search" for="lookup-search">
+                <label class="lookups-search search-field" for="lookup-search">
                     <span class="sr-only">Search entries</span>
-                    <span class="material-symbols-rounded" aria-hidden="true">search</span>
                     <input
                         type="search"
                         id="lookup-search"
                         placeholder="Search entries"
                         autocomplete="off"
+                        class="search-input"
                         data-search
                     />
                 </label>

--- a/templates/updates.html
+++ b/templates/updates.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>IGDB Updates</title>
+    <title>Update</title>
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@20..48,400,0,0" />
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}" />
@@ -15,7 +15,7 @@
             <a class="topbar-brand" href="{{ url_for('web.index') }}">Game Editor</a>
             <nav class="topbar-nav" aria-label="Global">
                 <a class="topbar-link" href="{{ url_for('web.index') }}">Editor</a>
-                <a class="topbar-link is-active" href="{{ url_for('updates.updates_page') }}">IGDB Updates</a>
+                <a class="topbar-link is-active" href="{{ url_for('updates.updates_page') }}">Update</a>
                 <a class="topbar-link" href="{{ url_for('lookups.lookups_page') }}">Lookups</a>
                 <a class="topbar-link" href="{{ url_for('web.logout') }}">Logout</a>
             </nav>
@@ -24,18 +24,18 @@
     <main class="updates-page">
         <header class="updates-header">
             <div class="updates-title">
-                <h1>IGDB Updates</h1>
+                <h1>Update</h1>
                 <p>Monitor pending changes from IGDB before applying them to the local catalog.</p>
             </div>
             <div class="updates-actions">
-                <label class="updates-search" for="updates-search">
+                <label class="updates-search search-field" for="updates-search">
                     <span class="sr-only">Search updates</span>
-                    <span class="material-symbols-rounded" aria-hidden="true">search</span>
                     <input
                         type="search"
                         id="updates-search"
                         placeholder="Search by game, ID or IGDB ID"
                         autocomplete="off"
+                        class="search-input"
                         data-search
                     />
                 </label>


### PR DESCRIPTION
## Summary
- rename the IGDB Updates navigation entry and page title to Update
- restyle the search inputs on the Update and Lookups pages to match the button treatment
- hide the Update page background job progress indicators whenever the jobs are idle

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6a4525764833396da6b916c7d4619