### PR TITLE
Validate IGDB credentials before refresh endpoints

### DIFF
--- a/app.py
+++ b/app.py
@@ -3039,6 +3039,7 @@ def configure_blueprints(flask_app: Flask) -> None:
     routes_updates.configure({
         'IGDB_BATCH_SIZE': IGDB_BATCH_SIZE,
         'FIX_NAMES_BATCH_LIMIT': FIX_NAMES_BATCH_LIMIT,
+        'validate_igdb_credentials': app_config.validate_igdb_credentials,
         'exchange_twitch_credentials': lambda: exchange_twitch_credentials,
         'db_lock': db_lock,
         'get_db': get_db,

--- a/routes/updates.py
+++ b/routes/updates.py
@@ -43,6 +43,9 @@ def updates_page():
 @updates_blueprint.route('/api/igdb/cache', methods=['POST'])
 @handle_api_errors
 def api_igdb_cache_refresh():
+    if not _ctx('validate_igdb_credentials')():
+        return jsonify({'error': 'IGDB credentials missing'}), 503
+
     payload = request.get_json(silent=True) or {}
     offset = payload.get('offset', 0)
     limit = payload.get('limit', _ctx('IGDB_BATCH_SIZE'))
@@ -119,6 +122,9 @@ def api_igdb_cache_refresh():
 @updates_blueprint.route('/api/updates/refresh', methods=['POST'])
 @handle_api_errors
 def api_updates_refresh():
+    if not _ctx('validate_igdb_credentials')():
+        return jsonify({'error': 'IGDB credentials missing'}), 503
+
     run_sync = request.args.get('sync') not in (None, '', '0', 'false', 'False') or current_app.config.get('TESTING')
     execute_refresh_job = _ctx('_execute_refresh_job')
     job_manager = _ctx('job_manager')


### PR DESCRIPTION
## Summary
- add a reusable validator that flags missing IGDB client credentials
- short-circuit IGDB refresh API routes with a 503 error when credentials are absent

## Testing
- pytest *(fails: schema-dependent tests expect refresh endpoints to run with credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68d7170f5fd08333b2ba20a021ca4bc8