### PR TITLE
Handle IGDB cache refresh runtime errors

### DIFF
--- a/routes/updates.py
+++ b/routes/updates.py
@@ -85,6 +85,9 @@ def api_igdb_cache_refresh():
     except RuntimeError as exc:
         raise UpstreamServiceError(str(exc)) from exc
 
+    if 'error' in result:
+        return jsonify(result), 502
+
     total = result.get('total') or 0
     processed = result.get('processed') or 0
     try:


### PR DESCRIPTION
## Summary
- catch runtime errors when fetching IGDB totals or batches and return an error payload that marks the sync as done
- have the IGDB cache refresh route surface backend errors to the client with a 502 response

## Testing
- pytest *(fails: sqlite3.OperationalError: no such table: processed_game_developers)*

------
https://chatgpt.com/codex/tasks/task_e_68d75fb30e748333ba2afb4d7d12656a