### PR TITLE
Support sync IGDB cache refresh in API tests

### DIFF
--- a/tests/app_helpers.py
+++ b/tests/app_helpers.py
@@ -48,6 +48,25 @@ def load_app(tmp_path: Path) -> object:
         module.app.config['TESTING'] = True
         module.app.testing = True
 
+    if hasattr(module, "routes_updates"):
+        module.routes_updates._context['validate_igdb_credentials'] = lambda: True
+
+    if hasattr(module, "exchange_twitch_credentials"):
+        module.exchange_twitch_credentials = lambda: ('token', 'client')
+
+    if hasattr(module, "igdb_api_client"):
+        module.igdb_api_client.exchange_twitch_credentials = (
+            lambda **_kwargs: ('token', 'client')
+        )
+
+    if hasattr(module, "_recreate_lookup_join_tables") and hasattr(module, "db"):
+        with module.db_lock:
+            module._recreate_lookup_join_tables(module.db)
+
+    if hasattr(module, "_ensure_lookup_id_columns") and hasattr(module, "db"):
+        with module.db_lock:
+            module._ensure_lookup_id_columns(module.db)
+
     return module
 
 


### PR DESCRIPTION
## Summary
- run the IGDB cache refresh endpoint through the background job manager unless the new sync flag (or test mode) is set
- extend the test helper to prepare lookup join tables for synchronous API runs and reuse stubbed credentials
- rewrite the IGDB cache API test to call the endpoint with `?sync=1` and assert on the direct payload

## Testing
- pytest tests/test_updates.py tests/test_updates_api.py

------
https://chatgpt.com/codex/tasks/task_e_68d7619eaf1c8333aa23a73eed14c48d