### PR TITLE
Add updates status API endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -975,6 +975,14 @@ def _init_db(*, run_migrations: bool = RUN_DB_MIGRATIONS) -> None:
 
             try:
                 conn.execute(
+                    'CREATE INDEX IF NOT EXISTS igdb_updates_refreshed_at_idx '
+                    'ON igdb_updates(refreshed_at)'
+                )
+            except sqlite3.OperationalError:
+                pass
+
+            try:
+                conn.execute(
                     f'''
                     CREATE TABLE IF NOT EXISTS {IGDB_CACHE_TABLE} (
                         igdb_id INTEGER PRIMARY KEY,


### PR DESCRIPTION
## Summary
- add a GET /api/updates/status endpoint that reports refresh progress, last refresh time, and job errors
- create an index on igdb_updates.refreshed_at to keep status lookups fast
- add unit tests covering idle, running, and completed refresh status responses

## Testing
- pytest tests/test_updates_api.py -k "updates_status"


------
https://chatgpt.com/codex/tasks/task_e_68d8a7cc9d08833393f0ae05c109aa0c