### PR TITLE
Add pagination to updates API and UI

### DIFF
--- a/routes/updates.py
+++ b/routes/updates.py
@@ -417,7 +417,32 @@ def api_updates_job_detail(job_id: str):
 @handle_api_errors
 def api_updates_list():
     fetch_cached_updates = _ctx('fetch_cached_updates')
-    return jsonify({'updates': fetch_cached_updates()})
+    try:
+        offset = int(request.args.get('offset', 0))
+    except (TypeError, ValueError):
+        offset = 0
+    if offset < 0:
+        offset = 0
+
+    try:
+        limit = int(request.args.get('limit', 100))
+    except (TypeError, ValueError):
+        limit = 100
+    if limit <= 0:
+        limit = 100
+    limit = min(limit, 500)
+
+    items, total, normalized_offset = fetch_cached_updates(
+        offset=offset, limit=limit
+    )
+    return jsonify(
+        {
+            'items': items,
+            'total': total,
+            'offset': normalized_offset,
+            'limit': limit,
+        }
+    )
 
 
 @updates_blueprint.route('/api/updates/<int:processed_game_id>', methods=['GET'])

--- a/static/style.css
+++ b/static/style.css
@@ -826,6 +826,59 @@ textarea {
   overflow-x: auto;
 }
 
+.table-pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  padding: 16px 20px;
+  border-top: 1px solid rgba(148, 163, 184, 0.1);
+  background: rgba(15, 23, 42, 0.25);
+  flex-wrap: wrap;
+}
+
+.pagination-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 14px;
+  border-radius: 999px;
+  border: 1px solid rgba(37, 99, 235, 0.4);
+  background: rgba(37, 99, 235, 0.15);
+  color: var(--color-text);
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 120ms ease, color 120ms ease, border-color 120ms ease;
+}
+
+.pagination-button .material-symbols-rounded {
+  font-size: 1.1rem;
+}
+
+.pagination-button[disabled],
+.pagination-button[aria-disabled='true'] {
+  cursor: not-allowed;
+  opacity: 0.5;
+  background: rgba(148, 163, 184, 0.2);
+  border-color: rgba(148, 163, 184, 0.25);
+}
+
+.pagination-button:hover:not([disabled]):not([aria-disabled='true']) {
+  background: rgba(37, 99, 235, 0.3);
+  border-color: rgba(37, 99, 235, 0.6);
+}
+
+.pagination-info {
+  color: var(--color-muted);
+  font-size: 0.95rem;
+  min-width: 120px;
+  text-align: center;
+}
+
+.pagination-label {
+  font-size: 0.9rem;
+}
+
 .updates-table {
   width: 100%;
   border-collapse: collapse;

--- a/templates/updates.html
+++ b/templates/updates.html
@@ -131,6 +131,17 @@
                     <tbody data-updates-body></tbody>
                 </table>
             </div>
+            <nav class="table-pagination" data-pagination hidden aria-label="Pagination">
+                <button type="button" class="pagination-button" data-page-prev aria-label="Previous page">
+                    <span class="material-symbols-rounded" aria-hidden="true">chevron_left</span>
+                    <span class="pagination-label">Previous</span>
+                </button>
+                <div class="pagination-info" data-page-info>Page 1 of 1</div>
+                <button type="button" class="pagination-button" data-page-next aria-label="Next page">
+                    <span class="material-symbols-rounded" aria-hidden="true">chevron_right</span>
+                    <span class="pagination-label">Next</span>
+                </button>
+            </nav>
             <div class="table-empty" data-empty-state hidden>
                 <p>No updates found. Try refreshing or adjust your search.</p>
             </div>


### PR DESCRIPTION
## Summary
- add persistent `has_diff` metadata and composite indexes to `igdb_updates`, and paginate cached update queries
- expose offset/limit parameters in `/api/updates` and update the web UI to fetch pages with navigation controls
- extend the updates API tests to cover the new response shape and pagination behaviour

## Testing
- pytest tests/test_updates_api.py


------
https://chatgpt.com/codex/tasks/task_e_68d8b2c1e844833397afe3cd8103cde8