### PR TITLE
Revamp updates page status display and cache reporting

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -782,66 +782,246 @@ textarea {
 }
 
 .updates-progress-stack {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
   margin: 16px 0 24px;
 }
 
-.updates-progress {
-  min-width: 0;
-  align-items: stretch;
-  padding: 16px 20px;
+.task-banner {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 20px;
   border-radius: 16px;
   border: 1px solid var(--color-border);
-  background: var(--color-surface-elevated);
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.12), rgba(28, 45, 74, 0.95));
   box-shadow: 0 18px 40px rgba(8, 15, 35, 0.35);
+  color: var(--color-text);
 }
 
-.updates-progress .progress-body {
+.task-banner-heading {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 20px;
-  flex-wrap: wrap;
+  gap: 14px;
 }
 
-.updates-progress .progress-info {
-  display: flex;
+.task-banner-icon {
+  display: inline-flex;
   align-items: center;
-  gap: 12px;
-  min-width: 220px;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 12px;
+  background: rgba(37, 99, 235, 0.18);
+  color: var(--color-blue);
+  font-size: 1.6rem;
 }
 
-.updates-progress .progress-icon {
-  font-size: 1.8rem;
+.task-banner-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.task-banner-title {
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.task-banner-note {
+  font-size: 0.85rem;
   color: var(--color-muted);
 }
 
-.updates-progress .progress-text {
+.task-banner-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.task-banner-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 12px 14px;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.45);
+  border: 1px solid rgba(37, 99, 235, 0.22);
+}
+
+.task-banner-item-main {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+}
+
+.task-banner-item-icon {
+  font-size: 1.4rem;
+  color: var(--color-muted);
+}
+
+.task-banner-item-text {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.task-banner-item-name {
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: var(--color-text);
+}
+
+.task-banner-item-message {
+  font-size: 0.85rem;
+  color: var(--color-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 420px;
+}
+
+.task-banner-item-progress {
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: var(--color-blue);
+  white-space: nowrap;
+}
+
+@media (max-width: 720px) {
+  .task-banner-item {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 10px;
+  }
+
+  .task-banner-item-progress {
+    align-self: flex-end;
+  }
+
+  .task-banner-item-message {
+    max-width: 100%;
+  }
+}
+
+.updates-cache-card {
+  margin-bottom: 24px;
+}
+
+.status-card {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 20px;
+  border-radius: 16px;
+  background: var(--color-surface-elevated);
+  border: 1px solid var(--color-border);
+  box-shadow: 0 16px 32px rgba(8, 15, 35, 0.25);
+}
+
+.status-card-header {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+
+.status-card-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 12px;
+  background: rgba(37, 99, 235, 0.18);
+  color: var(--color-blue);
+  font-size: 1.6rem;
+}
+
+.status-card-text {
   display: flex;
   flex-direction: column;
   gap: 4px;
 }
 
-.updates-progress .progress-title {
-  font-size: 1rem;
+.status-card-text h2 {
+  margin: 0;
+  font-size: 1.1rem;
   font-weight: 600;
-  color: var(--color-text);
 }
 
-.updates-progress .progress-message {
+.status-card-text p {
+  margin: 0;
   font-size: 0.9rem;
   color: var(--color-muted);
 }
 
-.updates-progress .progress-metrics {
-  align-items: baseline;
+.status-card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 16px;
+  margin: 0;
+  padding: 0;
 }
 
-.updates-progress .progress-bar {
-  width: 100%;
-  max-width: 100%;
+.status-card-metric {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.status-card-metric dt {
+  margin: 0;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-muted);
+}
+
+.status-card-metric dd {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.status-card-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.status-pill {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 10px 14px;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.4);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  min-width: 96px;
+}
+
+.status-pill span {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-muted);
+}
+
+.status-pill strong {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.status-card-footer {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--color-muted);
 }
 
 .updates-search {

--- a/templates/updates.html
+++ b/templates/updates.html
@@ -76,84 +76,64 @@
                 </div>
             </div>
         </header>
-        <section class="updates-progress-stack" data-progress-stack aria-live="polite">
-            <div class="progress-indicator updates-progress" data-refresh-progress role="status" hidden>
-                <div class="progress-body">
-                    <div class="progress-info">
-                        <span class="progress-icon material-symbols-rounded" aria-hidden="true">refresh</span>
-                        <div class="progress-text">
-                            <span class="progress-title">Updating IGDB cache</span>
-                            <span class="progress-message" data-refresh-message>Preparing IGDB cache…</span>
-                        </div>
-                    </div>
-                    <div class="progress-metrics">
-                        <span class="progress-count" data-refresh-count>0/0</span>
-                        <span class="progress-percent" data-refresh-percent>0%</span>
+        <section class="updates-progress-stack">
+            <div class="task-banner" data-task-banner hidden role="status" aria-live="polite">
+                <div class="task-banner-heading">
+                    <span class="task-banner-icon material-symbols-rounded" aria-hidden="true">sync</span>
+                    <div class="task-banner-text">
+                        <span class="task-banner-title">Tasks in progress</span>
+                        <span class="task-banner-note">These actions continue in the background.</span>
                     </div>
                 </div>
-                <div class="progress-bar">
-                    <div class="progress-fill" data-refresh-bar></div>
-                </div>
-            </div>
-            <div class="progress-indicator updates-progress" data-compare-progress role="status" hidden>
-                <div class="progress-body">
-                    <div class="progress-info">
-                        <span class="progress-icon material-symbols-rounded" aria-hidden="true">compare_arrows</span>
-                        <div class="progress-text">
-                            <span class="progress-title">Comparing catalog entries</span>
-                            <span class="progress-message" data-compare-message>Comparing processed games with the IGDB cache…</span>
-                        </div>
-                    </div>
-                    <div class="progress-metrics">
-                        <span class="progress-count" data-compare-count>0/0</span>
-                        <span class="progress-percent" data-compare-percent>0%</span>
-                    </div>
-                </div>
-                <div class="progress-bar">
-                    <div class="progress-fill" data-compare-bar></div>
-                </div>
-            </div>
-            <div class="progress-indicator updates-progress" data-fix-progress role="status" hidden>
-                <div class="progress-body">
-                    <div class="progress-info">
-                        <span class="progress-icon material-symbols-rounded" aria-hidden="true">spellcheck</span>
-                        <div class="progress-text">
-                            <span class="progress-title">Fixing IGDB names</span>
-                            <span class="progress-message" data-fix-message>Correcting processed game names using IGDB data…</span>
-                        </div>
-                    </div>
-                    <div class="progress-metrics">
-                        <span class="progress-count" data-fix-count>0/0</span>
-                        <span class="progress-percent" data-fix-percent>0%</span>
-                    </div>
-                </div>
-                <div class="progress-bar">
-                    <div class="progress-fill" data-fix-bar></div>
-                </div>
-            </div>
-            <div class="progress-indicator updates-progress" data-dedupe-progress role="status" hidden>
-                <div class="progress-body">
-                    <div class="progress-info">
-                        <span class="progress-icon material-symbols-rounded" aria-hidden="true">layers_clear</span>
-                        <div class="progress-text">
-                            <span class="progress-title">Removing duplicates</span>
-                            <span class="progress-message" data-dedupe-message>Cleaning duplicate IGDB entries…</span>
-                        </div>
-                    </div>
-                    <div class="progress-metrics">
-                        <span class="progress-count" data-dedupe-count>0/0</span>
-                        <span class="progress-percent" data-dedupe-percent>0%</span>
-                    </div>
-                </div>
-                <div class="progress-bar">
-                    <div class="progress-fill" data-dedupe-bar></div>
-                </div>
+                <ul class="task-banner-list" data-task-list></ul>
             </div>
         </section>
         <section class="updates-summary" aria-live="polite">
             <span>Total entries:</span>
             <strong data-count>0</strong>
             <span class="updates-status" data-refresh-status></span>
+        </section>
+        <section class="updates-cache-card" aria-live="polite">
+            <article class="status-card">
+                <header class="status-card-header">
+                    <span class="status-card-icon material-symbols-rounded" aria-hidden="true">database</span>
+                    <div class="status-card-text">
+                        <h2>IGDB Cache</h2>
+                        <p data-cache-status-message>Loading cache status…</p>
+                    </div>
+                </header>
+                <dl class="status-card-grid">
+                    <div class="status-card-metric">
+                        <dt>Cached entries</dt>
+                        <dd data-cache-count>—</dd>
+                    </div>
+                    <div class="status-card-metric">
+                        <dt>Last synced</dt>
+                        <dd data-cache-synced>—</dd>
+                    </div>
+                    <div class="status-card-metric">
+                        <dt>Remote total</dt>
+                        <dd data-cache-remote>—</dd>
+                    </div>
+                </dl>
+                <div class="status-card-summary" data-cache-summary hidden>
+                    <div class="status-pill">
+                        <span>Inserted</span>
+                        <strong data-cache-inserted>0</strong>
+                    </div>
+                    <div class="status-pill">
+                        <span>Updated</span>
+                        <strong data-cache-updated>0</strong>
+                    </div>
+                    <div class="status-pill">
+                        <span>Unchanged</span>
+                        <strong data-cache-unchanged>0</strong>
+                    </div>
+                </div>
+                <p class="status-card-footer" data-cache-refreshed hidden>
+                    Last refresh completed <span data-cache-refresh>—</span>.
+                </p>
+            </article>
         </section>
         <section class="updates-table-card">
             <div class="table-scroll" role="region" aria-live="polite" aria-label="Updates table">
@@ -261,6 +241,7 @@
             jobDetailUrlTemplate: {{ url_for('updates.api_updates_job_detail', job_id='job')|replace('job', '{id}')|tojson }},
             detailUrlTemplate: {{ url_for('updates.api_updates_detail', processed_game_id=0)|replace('0', '{id}')|tojson }},
             coverUrlTemplate: {{ url_for('updates.api_updates_cover', processed_game_id=0)|replace('0', '{id}')|tojson }},
+            cacheStatusUrl: {{ url_for('updates.api_updates_cache_status')|tojson }},
             cacheBatchSize: {{ igdb_batch_size|tojson }},
             fixBatchSize: {{ FIX_NAMES_BATCH_LIMIT|default(50)|tojson }}
         };


### PR DESCRIPTION
## Summary
- replace the updates page progress widgets with a consolidated task banner that hides when idle and matches the dark theme
- surface IGDB cache metrics via a new status card, backed by a `/api/updates/cache-status` endpoint and helper
- ensure the synchronous cache refresh response includes the expected metadata for frontend usage and tests

## Testing
- pytest tests/test_updates_api.py

------
https://chatgpt.com/codex/tasks/task_e_68dae555a3a88333ba9484a784a87f02