### PR TITLE
Optimize cache database performance

### DIFF
--- a/app.py
+++ b/app.py
@@ -1045,6 +1045,14 @@ def _init_db(*, run_migrations: bool = RUN_DB_MIGRATIONS) -> None:
 
             try:
                 conn.execute(
+                    f'''CREATE INDEX IF NOT EXISTS {IGDB_CACHE_TABLE}_updated_at_id_idx '''
+                    f'''ON {IGDB_CACHE_TABLE}(updated_at, igdb_id)'''
+                )
+            except sqlite3.OperationalError:
+                pass
+
+            try:
+                conn.execute(
                     'CREATE INDEX IF NOT EXISTS processed_games_igdb_id_idx '
                     'ON processed_games("igdb_id")'
                 )
@@ -1162,6 +1170,11 @@ def _init_db(*, run_migrations: bool = RUN_DB_MIGRATIONS) -> None:
                             game_id,
                         )
                         continue
+            if run_migrations:
+                try:
+                    conn.execute('ANALYZE')
+                except sqlite3.OperationalError:
+                    pass
     finally:
         conn.close()
 


### PR DESCRIPTION
## Summary
- configure SQLite connections to enable WAL, mmap, and cache-size pragmas for faster cache access and keep scripts aligned
- add an updated_at/igdb_id covering index to the cache table (with a Postgres variant) and run ANALYZE after migrations to refresh statistics
- reuse the shared cached-updates paginator for the updates API and allow a test-only formatter override

## Testing
- pytest tests/test_updates.py tests/test_updates_api.py

------
https://chatgpt.com/codex/tasks/task_e_68db21cc72b883339f9c36acc97d0df7