### PR TITLE
Cache updates listing in a materialized table

### DIFF
--- a/tests/app_helpers.py
+++ b/tests/app_helpers.py
@@ -77,9 +77,17 @@ def load_app(tmp_path: Path) -> object:
             lambda **_kwargs: ('token', 'client')
         )
 
+    if hasattr(module, "_load_lookup_tables") and hasattr(module, "db"):
+        with module.db_lock:
+            module._load_lookup_tables(module.db)
+
     if hasattr(module, "_recreate_lookup_join_tables") and hasattr(module, "db"):
         with module.db_lock:
             module._recreate_lookup_join_tables(module.db)
+
+    if hasattr(module, "_backfill_lookup_relations") and hasattr(module, "db"):
+        with module.db_lock:
+            module._backfill_lookup_relations(module.db)
 
     if hasattr(module, "_ensure_lookup_id_columns") and hasattr(module, "db"):
         with module.db_lock:

--- a/tests/test_lookup_api.py
+++ b/tests/test_lookup_api.py
@@ -25,6 +25,7 @@ def clear_processed_tables(app_module):
         'processed_game_game_modes',
         'processed_game_platforms',
         'processed_games',
+        'updates_list',
     )
     with app_module.db_lock:
         with app_module.db:


### PR DESCRIPTION
## Summary
- add an `updates_list` cache table and helper routines to precompute the API payload
- rewrite `fetch_cached_updates` to read from the cached table and refresh it after diff jobs
- update the test harness to rebuild the cached table and clean it between tests

## Testing
- pytest tests/test_lookup_tables.py::test_lookup_tables_backfilled -q
- pytest tests/test_navigator_state.py::test_out_of_order_ids_are_normalized -q
- pytest tests/test_updates.py::test_refresh_igdb_cache_inserts_and_updates -q
- pytest tests/test_updates_api.py::test_updates_list_since_filters_new_entries -q


------
https://chatgpt.com/codex/tasks/task_e_68db2a852e988333aeba0400285152ac