### PR TITLE
Add PATCH endpoint to patch processed games from IGDB cache

### DIFF
--- a/app.py
+++ b/app.py
@@ -3980,6 +3980,7 @@ def configure_blueprints(flask_app: Flask) -> None:
         'exchange_twitch_credentials': lambda: exchange_twitch_credentials,
         'db_lock': db_lock,
         'get_db': get_db,
+        'now_utc_iso': now_utc_iso,
         '_get_cached_igdb_total': _get_cached_igdb_total,
         '_set_cached_igdb_total': _set_cached_igdb_total,
         'download_igdb_game_count': lambda: download_igdb_game_count,

--- a/updates/service.py
+++ b/updates/service.py
@@ -2,24 +2,302 @@
 
 from __future__ import annotations
 
+import json
+import numbers
+import sqlite3
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import nullcontext
 from functools import partial
 from typing import Any, Callable, Iterable, Mapping, MutableMapping, Sequence
 
 from config import IGDB_USER_AGENT
+from helpers import _format_first_release_date, _normalize_lookup_name
 from igdb.cache import (
+    IGDB_CACHE_TABLE,
     get_cached_total as cache_get_cached_total,
     set_cached_total as cache_set_cached_total,
     upsert_igdb_games,
 )
 from igdb.client import (
+    IGDBClient,
     download_igdb_game_count as client_download_igdb_game_count,
     download_igdb_games as client_download_igdb_games,
+    map_igdb_genres,
+    map_igdb_modes,
 )
+from lookups.service import get_or_create_lookup_id
 
 
 ProgressCallback = Callable[..., None]
+
+
+def _quote_identifier(identifier: str) -> str:
+    text = str(identifier or "")
+    return f'"{text.replace("\"", "\"\"")}"'
+
+
+def _fetch_row_dict(
+    conn: sqlite3.Connection, sql: str, params: Iterable[Any] | None = None
+) -> dict[str, Any] | None:
+    cursor = conn.execute(sql, tuple(params or ()))
+    row = cursor.fetchone()
+    if row is None:
+        return None
+    columns = [description[0] for description in cursor.description]
+    return {
+        columns[index] if index < len(columns) else str(index): value
+        for index, value in enumerate(row)
+    }
+
+
+def _parse_cache_list(raw_value: Any) -> list[str]:
+    if raw_value in (None, ""):
+        return []
+    if isinstance(raw_value, str):
+        text = raw_value.strip()
+        if not text:
+            return []
+        try:
+            value = json.loads(text)
+        except json.JSONDecodeError:
+            return [
+                item
+                for item in (segment.strip() for segment in text.split(","))
+                if item
+            ]
+    elif isinstance(raw_value, (list, tuple)):
+        value = list(raw_value)
+    else:
+        value = [raw_value]
+    result: list[str] = []
+    for item in value or []:
+        text = str(item).strip()
+        if text:
+            result.append(text)
+    return result
+
+
+def _normalize_name_list(names: Iterable[str]) -> list[str]:
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for name in names:
+        text = _normalize_lookup_name(name)
+        if not text:
+            continue
+        key = text.casefold()
+        if key in seen:
+            continue
+        seen.add(key)
+        normalized.append(text)
+    return normalized
+
+
+def _encode_lookup_id_list(values: Iterable[int]) -> str:
+    normalized: list[int] = []
+    seen: set[int] = set()
+    for value in values:
+        try:
+            coerced = int(value)
+        except (TypeError, ValueError):
+            continue
+        if coerced in seen:
+            continue
+        seen.add(coerced)
+        normalized.append(coerced)
+    if not normalized:
+        return ""
+    return json.dumps(normalized)
+
+
+def _resolve_lookup_ids(
+    conn: sqlite3.Connection, table_name: str, names: Iterable[str]
+) -> list[int]:
+    identifiers: list[int] = []
+    seen: set[int] = set()
+    for name in _normalize_name_list(names):
+        lookup_id = get_or_create_lookup_id(
+            conn, table_name, name, normalize_lookup_name=_normalize_lookup_name
+        )
+        if lookup_id is None or lookup_id in seen:
+            continue
+        seen.add(lookup_id)
+        identifiers.append(lookup_id)
+    return identifiers
+
+
+def _coerce_igdb_id(value: Any) -> int | None:
+    if value in (None, ""):
+        return None
+    if isinstance(value, numbers.Integral):
+        return int(value)
+    try:
+        return int(str(value).strip())
+    except (TypeError, ValueError):
+        return None
+
+
+def apply_processed_game_patch(
+    processed_game_id: int,
+    field_actions: Mapping[str, Any],
+    *,
+    db_lock: Any,
+    get_db: Callable[[], sqlite3.Connection],
+    now_utc_iso: Callable[[], str],
+) -> dict[str, Any]:
+    """Apply cache-backed patches to a processed game entry."""
+
+    if processed_game_id is None:
+        raise ValueError("Processed game identifier is required.")
+    if not isinstance(field_actions, Mapping) or not field_actions:
+        raise ValueError("Field selections are required.")
+
+    normalized_actions: dict[str, str] = {}
+    for key, raw_action in field_actions.items():
+        if not key:
+            continue
+        action = str(raw_action or "").strip().lower()
+        if not action:
+            continue
+        normalized_actions[str(key)] = action
+
+    if not normalized_actions:
+        raise ValueError("No valid field selections provided.")
+
+    lookup_specs = {
+        "Developers": {"cache": "developers", "ids": "developers_ids", "table": "developers"},
+        "Publishers": {"cache": "publishers", "ids": "publishers_ids", "table": "publishers"},
+        "Platforms": {"cache": "platforms", "ids": "platforms_ids", "table": "platforms"},
+        "Genres": {"cache": "genres", "ids": "genres_ids", "table": "genres"},
+        "Game Modes": {"cache": "game_modes", "ids": "game_modes_ids", "table": "game_modes"},
+    }
+
+    with db_lock:
+        conn = get_db()
+        processed_row = _fetch_row_dict(
+            conn, 'SELECT * FROM processed_games WHERE "ID"=?', (processed_game_id,)
+        )
+        if not processed_row:
+            raise LookupError("Processed game not found.")
+
+        cache_row: dict[str, Any] | None = None
+        cache_required = any(
+            action.startswith("from_cache") for action in normalized_actions.values()
+        )
+        if cache_required:
+            igdb_id = _coerce_igdb_id(processed_row.get("igdb_id"))
+            if igdb_id is None:
+                raise ValueError("Processed game is missing an IGDB identifier.")
+            cache_row = _fetch_row_dict(
+                conn,
+                f"SELECT * FROM {_quote_identifier(IGDB_CACHE_TABLE)} WHERE igdb_id=?",
+                (igdb_id,),
+            )
+            if cache_row is None:
+                raise ValueError("IGDB cache entry not found for processed game.")
+
+        pragma_cursor = conn.execute('PRAGMA table_info("processed_games")')
+        processed_columns = {row[1] for row in pragma_cursor.fetchall() if len(row) > 1}
+
+        updates: dict[str, Any] = {}
+        lookup_names: dict[str, list[str]] = {}
+
+        for field_name, action in normalized_actions.items():
+            if action == "keep_current":
+                continue
+            if not action.startswith("from_cache"):
+                raise ValueError(f"Unsupported action '{action}' for field '{field_name}'.")
+            if cache_row is None:
+                raise ValueError("IGDB cache entry required to fulfil selection.")
+
+            cache_key = field_name
+            value: Any = None
+
+            if field_name == "Name":
+                cache_key = "name"
+                value = cache_row.get(cache_key)
+                value = value.strip() if isinstance(value, str) else value
+            elif field_name == "Summary":
+                cache_key = "summary"
+                value = cache_row.get(cache_key)
+                value = value.strip() if isinstance(value, str) else value
+            elif field_name == "First Launch Date":
+                cache_key = "first_release_date"
+                value = _format_first_release_date(cache_row.get(cache_key))
+            elif field_name == "Category":
+                cache_key = "category"
+                value = IGDBClient.translate_category(cache_row.get(cache_key))
+            elif field_name in lookup_specs:
+                spec = lookup_specs[field_name]
+                cache_key = spec["cache"]
+                raw_names = _parse_cache_list(cache_row.get(cache_key))
+                if field_name == "Genres" and action == "from_cache_mapped":
+                    mapped = map_igdb_genres(raw_names)
+                elif field_name == "Game Modes" and action == "from_cache_mapped":
+                    mapped = map_igdb_modes(raw_names)
+                else:
+                    mapped = raw_names
+                normalized_names = _normalize_name_list(mapped)
+                lookup_names[field_name] = normalized_names
+                value = ", ".join(normalized_names)
+            else:
+                raise ValueError(f"Unsupported field '{field_name}'.")
+
+            column_exists = field_name in processed_columns
+            if not column_exists and field_name in lookup_specs:
+                column_exists = lookup_specs[field_name]["ids"] in processed_columns
+            if not column_exists:
+                continue
+
+            if isinstance(value, str):
+                updates[field_name] = value
+            elif value is None:
+                updates[field_name] = ""
+            else:
+                updates[field_name] = str(value)
+
+        if not updates:
+            raise ValueError("No cache fields could be applied to the processed game.")
+
+        for field_name, names in lookup_names.items():
+            spec = lookup_specs[field_name]
+            ids_column = spec.get("ids")
+            table_name = spec.get("table")
+            if not ids_column or ids_column not in processed_columns:
+                continue
+            if not table_name:
+                continue
+            ids = _resolve_lookup_ids(conn, table_name, names)
+            updates[ids_column] = _encode_lookup_id_list(ids)
+
+        timestamp: str | None = None
+        if "last_edited_at" in processed_columns:
+            timestamp = now_utc_iso()
+            updates["last_edited_at"] = timestamp
+
+        set_fragments: list[str] = []
+        params: list[Any] = []
+        for column, value in updates.items():
+            if column not in processed_columns:
+                continue
+            set_fragments.append(f"{_quote_identifier(column)} = ?")
+            params.append(value)
+
+        if not set_fragments:
+            raise ValueError("No valid processed columns were updated.")
+
+        params.append(processed_game_id)
+        conn.execute(
+            f"UPDATE processed_games SET {', '.join(set_fragments)} WHERE \"ID\" = ?",
+            params,
+        )
+        conn.commit()
+
+    updated_fields = [column for column in updates if column in processed_columns]
+    return {
+        "processed_game_id": processed_game_id,
+        "updated_fields": sorted(updated_fields),
+        "last_edited_at": updates.get("last_edited_at") if "last_edited_at" in updates else None,
+    }
 
 
 def _resolve_route_helper(name: str, fallback: Any) -> Any:


### PR DESCRIPTION
## Summary
- add a service helper that builds cache-backed patches for processed games, translating and mapping lookup values as needed
- expose a PATCH /api/updates/<processed_game_id>/apply endpoint that uses the new helper and validates payloads
- share the now_utc_iso helper with the updates blueprint so patch operations timestamp edits

## Testing
- pytest tests/test_updates_api.py::test_updates_detail_returns_diff


------
https://chatgpt.com/codex/tasks/task_e_68e06e730c84833390717927a55773d1