### PR TITLE
Remove fix and dedupe bulk actions from updates UI

### DIFF
--- a/static/updates.js
+++ b/static/updates.js
@@ -106,8 +106,6 @@
         countLabel: document.querySelector('[data-count]'),
         statusLabel: document.querySelector('[data-refresh-status]'),
         sortButtons: Array.from(document.querySelectorAll('.sort-button[data-sort]')),
-        fixButton: document.querySelector('[data-fix-names]'),
-        dedupeButton: document.querySelector('[data-remove-duplicates]'),
         taskBanner: document.querySelector('[data-task-banner]'),
         taskList: document.querySelector('[data-task-list]'),
         cacheStatusMessage: document.querySelector('[data-cache-status-message]'),
@@ -1972,58 +1970,6 @@
         return payload;
     }
 
-    async function handleFixNames() {
-        if (state.fixingNames) {
-            return;
-        }
-        if (!config.fixNamesUrl) {
-            showToast('Name fixing endpoint is not configured.', 'warning');
-            return;
-        }
-        state.fixingNames = true;
-        setFixButtonLoading(true);
-        setFixProgressVisible(true);
-        updateFixProgress(0, 0);
-        try {
-            const job = await startJob(config.fixNamesUrl);
-            monitorJob(job);
-        } catch (error) {
-            console.error(error);
-            showToast(error.message, 'warning');
-            state.fixingNames = false;
-            setFixButtonLoading(false);
-            updateFixProgress(0, 0);
-            setFixProgressVisible(false);
-        } finally {
-            // Loading state will be reset when the job completes or fails.
-        }
-    }
-
-    async function handleRemoveDuplicates() {
-        if (state.deduping) {
-            return;
-        }
-        if (!config.removeDuplicatesUrl) {
-            showToast('Duplicate removal endpoint is not configured.', 'warning');
-            return;
-        }
-        state.deduping = true;
-        setDedupeButtonLoading(true);
-        setDedupeProgressVisible(true);
-        updateDedupeProgress(0, 0);
-        try {
-            const job = await startJob(config.removeDuplicatesUrl);
-            monitorJob(job);
-        } catch (error) {
-            console.error(error);
-            showToast(error.message, 'warning');
-            state.deduping = false;
-            setDedupeButtonLoading(false);
-            updateDedupeProgress(0, 0);
-            setDedupeProgressVisible(false);
-        }
-    }
-
     async function handleDeleteDuplicate(item, button) {
         if (!item || !item.processed_game_id) {
             return;
@@ -2870,12 +2816,6 @@
         }
         if (elements.compareButton) {
             elements.compareButton.addEventListener('click', handleCompare);
-        }
-        if (elements.fixButton) {
-            elements.fixButton.addEventListener('click', handleFixNames);
-        }
-        if (elements.dedupeButton) {
-            elements.dedupeButton.addEventListener('click', handleRemoveDuplicates);
         }
         if (modal.closeButton) {
             modal.closeButton.addEventListener('click', closeModal);

--- a/templates/updates.html
+++ b/templates/updates.html
@@ -56,24 +56,6 @@
                         <span class="sr-only">Compare processed games with the cached IGDB data</span>
                     </button>
                 </div>
-                <div class="updates-bulk-action">
-                    <button type="button" class="btn btn-green" data-fix-names>
-                        <span class="btn-icon" aria-hidden="true">
-                            <span class="material-symbols-rounded">spellcheck</span>
-                        </span>
-                        <span class="btn-label">Fix IGDB Names</span>
-                        <span class="sr-only">Fix processed game names using IGDB data</span>
-                    </button>
-                </div>
-                <div class="updates-bulk-action">
-                    <button type="button" class="btn btn-red" data-remove-duplicates>
-                        <span class="btn-icon" aria-hidden="true">
-                            <span class="material-symbols-rounded">layers_clear</span>
-                        </span>
-                        <span class="btn-label">Remove Duplicates</span>
-                        <span class="sr-only">Remove unprocessed duplicate IGDB entries</span>
-                    </button>
-                </div>
             </div>
         </header>
         <section class="updates-progress-stack">
@@ -234,15 +216,12 @@
             refreshUrl: {{ url_for('updates.api_updates_refresh')|tojson }},
             cacheRefreshUrl: {{ url_for('updates.api_igdb_cache_refresh')|tojson }},
             compareUrl: {{ url_for('updates.api_updates_compare')|tojson }},
-            fixNamesUrl: {{ url_for('updates.api_updates_fix_names')|tojson }},
-            removeDuplicatesUrl: {{ url_for('updates.api_updates_remove_duplicates')|tojson }},
             deleteDuplicateBaseUrl: {{ url_for('updates.api_updates_remove_duplicate', processed_game_id=0).rsplit('/', 1)[0]|tojson }},
             jobsUrl: {{ url_for('updates.api_updates_job_list')|tojson }},
             detailBaseUrl: {{ url_for('updates.api_updates_detail', processed_game_id=0).rsplit('/', 1)[0]|tojson }},
             coverBaseUrl: {{ url_for('updates.api_updates_cover', processed_game_id=0).rsplit('/', 2)[0]|tojson }},
             cacheStatusUrl: {{ url_for('updates.api_updates_cache_status')|tojson }},
-            cacheBatchSize: {{ igdb_batch_size|tojson }},
-            fixBatchSize: {{ FIX_NAMES_BATCH_LIMIT|default(50)|tojson }}
+            cacheBatchSize: {{ igdb_batch_size|tojson }}
         };
     </script>
     <script src="{{ url_for('static', filename='updates.js') }}" defer></script>


### PR DESCRIPTION
## Summary
- remove the Fix IGDB Names and Remove Duplicates bulk actions from the updates page
- drop the associated configuration entries and client-side handlers for the removed buttons

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68e0778da5588333bd79d951c82ffd20