### PR TITLE
Add pagination support to lookup API

### DIFF
--- a/app.py
+++ b/app.py
@@ -700,9 +700,19 @@ def _remove_lookup_id_from_entries(
     lookups_service.remove_lookup_id_from_entries(entries, relation, lookup_id)
 
 
-def _list_lookup_entries(conn: sqlite3.Connection, table_name: str) -> list[dict[str, Any]]:
+def _list_lookup_entries(
+    conn: sqlite3.Connection,
+    table_name: str,
+    *,
+    limit: int,
+    offset: int,
+) -> tuple[list[dict[str, Any]], int]:
     return lookups_service.list_lookup_entries(
-        conn, table_name, normalize_lookup_name=_normalize_lookup_name
+        conn,
+        table_name,
+        normalize_lookup_name=_normalize_lookup_name,
+        limit=limit,
+        offset=offset,
     )
 
 


### PR DESCRIPTION
## Summary
- add pagination parameters and total counts to the lookup GET endpoint
- update the lookup service helper to provide paginated results
- add coverage ensuring lookup pagination works as expected

## Testing
- pytest tests/test_lookup_api.py

------
https://chatgpt.com/codex/tasks/task_e_68e08a8af8d083338ea57e7fa84023f6