### PR TITLE
Ensure resolve_cover returns static placeholder fallback

### DIFF
--- a/tests/test_resolve_cover.py
+++ b/tests/test_resolve_cover.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from tests.app_helpers import load_app
+
+
+def test_resolve_cover_uses_static_placeholder(tmp_path):
+    app_module = load_app(tmp_path)
+
+    result = app_module.resolve_cover()
+
+    assert result == '/static/no-image.jpg'
+
+
+def test_resolve_cover_handles_static_placeholder_override(tmp_path):
+    app_module = load_app(tmp_path)
+
+    result = app_module.resolve_cover(placeholder='/static/custom-placeholder.png')
+
+    assert result == '/static/custom-placeholder.png'
+
+
+def test_resolve_cover_preserves_absolute_placeholder(tmp_path):
+    app_module = load_app(tmp_path)
+    placeholder = 'https://example.com/fallback.png'
+
+    result = app_module.resolve_cover(placeholder=placeholder)
+
+    assert result == placeholder
+
+
+def test_static_placeholder_file_exists(tmp_path):
+    app_module = load_app(tmp_path)
+
+    module_root = Path(app_module.__file__).resolve().parent
+    static_path = module_root / 'static' / 'no-image.jpg'
+
+    assert static_path.is_file()


### PR DESCRIPTION
## Summary
- update the resolve_cover helper to default to the shared /static/no-image.jpg placeholder
- normalize placeholder inputs so static URLs are generated consistently without an app context
- add tests to verify the fallback behavior and confirm the placeholder asset exists

## Testing
- pytest tests/test_resolve_cover.py

------
https://chatgpt.com/codex/tasks/task_e_68e08ef9f21c83339a887700826a33ab