### PR TITLE
Add MariaDB configuration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,15 @@ These steps assume a fresh Ubuntu/Debian-like host. Adjust package manager comma
    pip install -r requirements.txt
    ```
 5. **Seed optional cover assets.** Download or export any existing cover art into the `covers_out/` directory. The server will create other needed folders (`uploaded_sources/`, `processed_covers/`) on first run.【F:app.py†L70-L100】
-6. **Configure environment variables.** Create a `.env` file or export the following before launching:
-   - `TWITCH_CLIENT_ID` / `TWITCH_CLIENT_SECRET` – required to exchange a Twitch OAuth token for IGDB access.【F:app.py†L1515-L1556】【F:app.py†L1858-L1890】
-   - `APP_PASSWORD` – shared password for the login form (defaults to `password`).
-   - `APP_SECRET_KEY` – Flask session secret; set a random string in production.
-   - `OPENAI_API_KEY` – optional, required only if you want to enable AI-generated summaries.
-   - `IGDB_USER_AGENT` – optional, overrides the default User-Agent header if your integration needs a specific contact address.【F:app.py†L146-L147】【F:app.py†L1545-L1562】
+6. **Configure environment variables.** Create a `.env` file (keep it out of version control) or export the following before launching. In production prefer Docker/Kubernetes secrets, cloud secret managers, or other deployment-specific vaults so real credentials never land in Git history:
+    - `TWITCH_CLIENT_ID` / `TWITCH_CLIENT_SECRET` – required to exchange a Twitch OAuth token for IGDB access.【F:app.py†L1515-L1556】【F:app.py†L1858-L1890】
+    - `APP_PASSWORD` – shared password for the login form (defaults to `password`).
+    - `APP_SECRET_KEY` – Flask session secret; set a random string in production.
+    - `OPENAI_API_KEY` – optional, required only if you want to enable AI-generated summaries.
+    - `IGDB_USER_AGENT` – optional, overrides the default User-Agent header if your integration needs a specific contact address.【F:app.py†L146-L147】【F:app.py†L1545-L1562】
+    - `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PASSWORD` – MariaDB connection settings used to reach the processed-games database. Keep `DB_PASSWORD` (and any other credentials) in a secure secret store; never commit real passwords or copy them into shared `.env` files.
+    - `DB_SSL_CA` – optional path to a CA bundle when the MariaDB server requires SSL validation.
+    - `DB_CONNECT_TIMEOUT` / `DB_READ_TIMEOUT` – optional overrides for connection and read timeouts when tuning long-running queries.
 7. **Initialize or repair existing data (optional).** If you have a legacy `processed_games.db`, run `python scripts/resync_db.py` to align it with the freshly fetched IGDB source order. To normalise old cover filenames execute `python migrate_cover_paths.py`.
 8. **Start the application.**
    ```bash
@@ -66,7 +69,7 @@ These steps assume a fresh Ubuntu/Debian-like host. Adjust package manager comma
 
 - Keep periodic backups of `processed_games.db` and the `processed_covers/` directory—they contain the authoritative edited content.【F:app.py†L248-L338】
 - If the navigation counters ever drift from the IGDB source order, rerun `python scripts/resync_db.py` to resequence IDs and restore alignment.【F:scripts/resync_db.py†L1-L75】
-- Enable HTTPS and set a strong `APP_PASSWORD`/`APP_SECRET_KEY` when deploying on the public internet.
+- Enable HTTPS and set a strong `APP_PASSWORD`/`APP_SECRET_KEY` when deploying on the public internet. Store those secrets alongside your database credentials in your orchestration layer instead of the repository or sample `.env` files.
 - When the AI summary feature is disabled (no OpenAI key), the “Gerar Resumo” button will raise a friendly warning instead of generating text.【F:app.py†L212-L247】【F:static/main.js†L119-L148】
 
 This README complements the short-form instructions in [INSTALL.md](INSTALL.md) with more operational context.

--- a/app.py
+++ b/app.py
@@ -39,15 +39,15 @@ from config import (
     APP_PASSWORD,
     APP_SECRET_KEY,
     COVERS_DIR,
+    DB_CONNECT_TIMEOUT_SECONDS,
+    DB_DSN,
     IGDB_BATCH_SIZE,
     IGDB_USER_AGENT,
     INPUT_XLSX,
     OPENAI_API_KEY,
     OPENAI_SUMMARY_ENABLED,
-    PROCESSED_DB,
     PROCESSED_DIR,
     RUN_DB_MIGRATIONS,
-    SQLITE_TIMEOUT_SECONDS,
     UPLOAD_DIR,
     get_lookup_data_dir,
     LOG_FILE,
@@ -182,9 +182,12 @@ def _configure_logging(flask_app: Flask) -> None:
     logger.setLevel(log_level)
 
 def _db_connection_factory() -> sqlite3.Connection:
-    return db_utils._create_sqlite_connection(
-        PROCESSED_DB, timeout=SQLITE_TIMEOUT_SECONDS
-    )
+    try:
+        return db_utils.create_connection_from_dsn(
+            DB_DSN, timeout=DB_CONNECT_TIMEOUT_SECONDS
+        )
+    except ValueError as exc:  # pragma: no cover - defensive guard for new configs
+        raise RuntimeError(f"Unsupported database DSN: {DB_DSN}") from exc
 
 LOOKUP_DATA_DIR = get_lookup_data_dir()
 


### PR DESCRIPTION
## Summary
- expose MariaDB connection configuration in `config.py`, build a DSN, and publish generic timeout settings
- update the Flask app and maintenance script to consume the DSN via the shared database utility helpers
- document the new database environment variables and secret-storage guidance in the README

## Testing
- python -m compileall config.py app.py db/utils.py scripts/rename_names_from_igdb.py

------
https://chatgpt.com/codex/tasks/task_e_68e0a3643cec83339e183bf5fa4f2ac0