### PR TITLE
Switch to SQLAlchemy DSN for MariaDB

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -14,6 +14,11 @@
    - Optional variables:
      - `OPENAI_API_KEY` enables automated Portuguese summaries.
      - `IGDB_USER_AGENT` customises the User-Agent header sent to IGDB.
+     - `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PASSWORD` configure the MariaDB connection. The app uses SQLAlchemy URLs (`mysql+pymysql://…`) and requires the pure-Python [`PyMySQL`](https://pypi.org/project/PyMySQL/) driver included in `requirements.txt`.
+     - `DB_SSL_CA` provides an SSL CA bundle when the database enforces TLS validation.
+     - `DB_CONNECT_TIMEOUT` / `DB_READ_TIMEOUT` tune connection/read timeouts in seconds.
+     - `DB_LEGACY_SQLITE=1` forces the historical `processed_games.db` SQLite file if you cannot provision MariaDB yet.
+     - `DB_SQLITE_PATH` overrides the SQLite location when `DB_LEGACY_SQLITE=1` (defaults to `processed_games.db` in the current working directory).
 
 3. **(Optional) Add existing artwork**
    - Drop any pre-supplied cover assets into the `covers_out/` directory.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ Pillow
 openai
 celery
 redis
+SQLAlchemy
+PyMySQL

--- a/tests/app_helpers.py
+++ b/tests/app_helpers.py
@@ -23,9 +23,14 @@ def load_app(tmp_path: Path) -> object:
         raise RuntimeError("Unable to load app module specification")
     module = importlib.util.module_from_spec(spec)
 
-    env_vars = {key: os.environ.get(key) for key in ("TWITCH_CLIENT_ID", "TWITCH_CLIENT_SECRET")}
+    env_vars = {
+        key: os.environ.get(key)
+        for key in ("TWITCH_CLIENT_ID", "TWITCH_CLIENT_SECRET", "DB_LEGACY_SQLITE")
+    }
     for key in env_vars:
         os.environ.pop(key, None)
+
+    os.environ["DB_LEGACY_SQLITE"] = "1"
 
     try:
         spec.loader.exec_module(module)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,9 @@
+import os
+
 import pytest
+
+
+os.environ.setdefault('DB_LEGACY_SQLITE', '1')
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Summary
- build SQLAlchemy-compatible MariaDB DSNs in the configuration, forwarding SSL/timeout parameters and adding an opt-in legacy SQLite mode
- add PyMySQL/SQLAlchemy runtime dependencies and document the new database environment variables and driver prerequisites
- ensure the test harness opts into the legacy SQLite path during imports so existing suites keep using SQLite fixtures

## Testing
- pytest *(fails: several suites now surface pre-existing unique constraint assertions when run against freshly seeded SQLite databases)*

------
https://chatgpt.com/codex/tasks/task_e_68e0a76d0c10833394ac37dd5a0045c8