### PR TITLE
Refactor database utilities to use SQLAlchemy engine

### DIFF
--- a/processed/navigator.py
+++ b/processed/navigator.py
@@ -10,6 +10,7 @@ import pandas as pd
 import sqlite3
 
 from . import source_index_cache
+from db import utils as db_utils
 
 
 class GameNavigator:
@@ -19,7 +20,7 @@ class GameNavigator:
         self,
         *,
         db_lock: Lock,
-        get_db: Callable[[], sqlite3.Connection],
+        get_db: Callable[[], db_utils.DatabaseHandle],
         is_processed_game_done: Callable[[Any, Any], bool],
         logger: logging.Logger | None = None,
     ) -> None:

--- a/tests/test_updates.py
+++ b/tests/test_updates.py
@@ -1,6 +1,5 @@
 """Unit and integration tests for IGDB cache refresh utilities."""
 from __future__ import annotations
-import sqlite3
 from threading import RLock
 from typing import Any
 from unittest.mock import patch
@@ -9,6 +8,7 @@ from igdb.cache import IGDB_CACHE_STATE_TABLE, IGDB_CACHE_TABLE
 from updates.service import refresh_igdb_cache
 
 from tests.app_helpers import load_app
+from db import utils as db_utils
 
 
 def authenticate(client: Any) -> None:
@@ -54,11 +54,11 @@ def _create_payload(
 def test_refresh_igdb_cache_inserts_and_updates() -> None:
     """Ensure ``refresh_igdb_cache`` performs inserts and updates correctly."""
 
-    conn = sqlite3.connect(':memory:')
-    conn.row_factory = sqlite3.Row
+    engine = db_utils.build_engine_from_dsn('sqlite:///:memory:')
+    conn = db_utils.DatabaseHandle(engine)
     db_lock = RLock()
 
-    def get_db() -> sqlite3.Connection:
+    def get_db() -> db_utils.DatabaseHandle:
         return conn
 
     initial_payloads = [


### PR DESCRIPTION
## Summary
- add a SQLAlchemy-powered DatabaseEngine and DatabaseHandle helper to db/utils.py, update connection caching, and delegate identifier quoting to SQLAlchemy
- migrate app initialization, scripts, and cache/update utilities to use the new database handle abstractions
- adjust navigator logic and tests to work with the SQLAlchemy-backed connections

## Testing
- `pytest tests/test_updates.py` *(fails: SQLAlchemy dependency unavailable in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0a97197148333988393f3cc22284d