### PR TITLE
Add SQLAlchemy helpers for database access

### DIFF
--- a/db/utils.py
+++ b/db/utils.py
@@ -273,6 +273,60 @@ def get_db(
     return _fallback_connection
 
 
+@contextmanager
+def get_db_connection(
+    connection_factory: Callable[[], DatabaseHandle | DatabaseEngine] | None = None,
+    *,
+    context_key: str = 'db',
+    use_global_fallback: bool = True,
+) -> Iterator[sqlite3.Connection]:
+    """Yield a DBAPI connection from the active database handle."""
+
+    handle = get_db(
+        connection_factory,
+        context_key=context_key,
+        use_global_fallback=use_global_fallback,
+    )
+    with handle.connection() as conn:
+        yield conn
+
+
+@contextmanager
+def get_db_sa_connection(
+    connection_factory: Callable[[], DatabaseHandle | DatabaseEngine] | None = None,
+    *,
+    context_key: str = 'db',
+    use_global_fallback: bool = True,
+) -> Iterator[Connection]:
+    """Yield a SQLAlchemy :class:`~sqlalchemy.engine.Connection`."""
+
+    handle = get_db(
+        connection_factory,
+        context_key=context_key,
+        use_global_fallback=use_global_fallback,
+    )
+    with handle.sa_connection() as conn:
+        yield conn
+
+
+@contextmanager
+def get_db_session(
+    connection_factory: Callable[[], DatabaseHandle | DatabaseEngine] | None = None,
+    *,
+    context_key: str = 'db',
+    use_global_fallback: bool = True,
+) -> Iterator[Session]:
+    """Yield a SQLAlchemy :class:`~sqlalchemy.orm.Session`."""
+
+    handle = get_db(
+        connection_factory,
+        context_key=context_key,
+        use_global_fallback=use_global_fallback,
+    )
+    with handle.session() as session:
+        yield session
+
+
 def get_processed_games_columns(
     conn: sqlite3.Connection | None = None,
     *,


### PR DESCRIPTION
## Summary
- extend the database utilities with context-managed helpers for DBAPI, SQLAlchemy connection, and session access
- update application helpers to expose the new database utilities and to handle SQLAlchemy row mappings
- adjust update tests to execute queries through SQLAlchemy connection mappings

## Testing
- pytest tests/test_updates.py *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68e0b6749cf48333820a27b65d8f8d83