### PR TITLE
Update initialization to use SQLAlchemy engine fallback

### DIFF
--- a/tests/app_helpers.py
+++ b/tests/app_helpers.py
@@ -85,40 +85,40 @@ def load_app(tmp_path: Path) -> object:
         )
 
     if hasattr(module, "_ensure_lookup_join_tables") and hasattr(module, "db"):
-        with module.db_lock:
-            module._ensure_lookup_join_tables(module.db)
+        with module.db_lock, module.db.connection() as conn:
+            module._ensure_lookup_join_tables(conn)
 
     if (
         run_migrations
         and hasattr(module, "_load_lookup_tables")
         and hasattr(module, "db")
     ):
-        with module.db_lock:
-            module._load_lookup_tables(module.db)
+        with module.db_lock, module.db.connection() as conn:
+            module._load_lookup_tables(conn)
 
     if (
         run_migrations
         and hasattr(module, "_recreate_lookup_join_tables")
         and hasattr(module, "db")
     ):
-        with module.db_lock:
-            module._recreate_lookup_join_tables(module.db)
+        with module.db_lock, module.db.connection() as conn:
+            module._recreate_lookup_join_tables(conn)
 
     if (
         run_migrations
         and hasattr(module, "_backfill_lookup_relations")
         and hasattr(module, "db")
     ):
-        with module.db_lock:
-            module._backfill_lookup_relations(module.db)
+        with module.db_lock, module.db.connection() as conn:
+            module._backfill_lookup_relations(conn)
 
     if (
         run_migrations
         and hasattr(module, "_ensure_lookup_id_columns")
         and hasattr(module, "db")
     ):
-        with module.db_lock:
-            module._ensure_lookup_id_columns(module.db)
+        with module.db_lock, module.db.connection() as conn:
+            module._ensure_lookup_id_columns(conn)
 
     return module
 


### PR DESCRIPTION
## Summary
- update the initialization routine to register and return the SQLAlchemy engine produced by the connection factory
- extend the database utility fallback management to handle DatabaseEngine instances while preserving DatabaseHandle compatibility
- switch the Flask bootstrap and test helpers to rely on the engine factory and explicitly manage temporary sqlite connections

## Testing
- pytest tests/test_db_creation.py *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68e0b7f90ee4833399d4f593e1ff8749