### PR TITLE
Refactor lookup service helpers to use SQLAlchemy connections

### DIFF
--- a/tests/app_helpers.py
+++ b/tests/app_helpers.py
@@ -93,7 +93,7 @@ def load_app(tmp_path: Path) -> object:
         and hasattr(module, "_load_lookup_tables")
         and hasattr(module, "db")
     ):
-        with module.db_lock, module.db.connection() as conn:
+        with module.db_lock, module.db.sa_connection() as conn:
             module._load_lookup_tables(conn)
 
     if (
@@ -109,7 +109,7 @@ def load_app(tmp_path: Path) -> object:
         and hasattr(module, "_backfill_lookup_relations")
         and hasattr(module, "db")
     ):
-        with module.db_lock, module.db.connection() as conn:
+        with module.db_lock, module.db.sa_connection() as conn:
             module._backfill_lookup_relations(conn)
 
     if (
@@ -117,7 +117,7 @@ def load_app(tmp_path: Path) -> object:
         and hasattr(module, "_ensure_lookup_id_columns")
         and hasattr(module, "db")
     ):
-        with module.db_lock, module.db.connection() as conn:
+        with module.db_lock, module.db.sa_connection() as conn:
             module._ensure_lookup_id_columns(conn)
 
     return module


### PR DESCRIPTION
## Summary
- refactor lookup service helpers to operate exclusively on SQLAlchemy connections/sessions, including new connection resolution utilities and SQLAlchemy Core CRUD statements
- update application lookup wrappers and routes to open SQLAlchemy connections from DatabaseHandle, committing mutations after service calls
- adjust test helpers to reuse SQLAlchemy connections during lookup table setup and backfill steps

## Testing
- pytest tests/test_lookup_api.py::test_lookup_get_supports_pagination[developers] -q

------
https://chatgpt.com/codex/tasks/task_e_68e1201ef3b4833384e362af15b27db9