### PR TITLE
Adapt database utilities and lookups for MariaDB

### DIFF
--- a/tests/test_lookup_tables.py
+++ b/tests/test_lookup_tables.py
@@ -1,6 +1,7 @@
 import os
 import json
 import sqlite3
+from collections.abc import Mapping
 from pathlib import Path
 
 import pandas as pd
@@ -97,7 +98,7 @@ def test_lookup_tables_backfilled(tmp_path):
         assert {row['name'] for row in platform_rows} == {"PC"}
 
         columns = {
-            row['name'] if isinstance(row, sqlite3.Row) else row[1]
+            row['name'] if isinstance(row, Mapping) else row[1]
             for row in app.db.execute('PRAGMA table_info(processed_games)')
         }
         assert 'developers_ids' in columns
@@ -110,7 +111,7 @@ def test_lookup_tables_backfilled(tmp_path):
         def first_lookup_id(query: str, processed_game_id: int) -> int:
             row = app.db.execute(query, (processed_game_id,)).fetchone()
             assert row is not None
-            if isinstance(row, sqlite3.Row):
+            if isinstance(row, Mapping):
                 return row[0]
             return row[0]
 


### PR DESCRIPTION
## Summary
- generalize the shared database utilities to translate DB-API parameter styles, wrap cursor results, and configure MariaDB session timeouts while still supporting SQLite metadata lookups
- add dialect-aware lookup-table upsert handling that issues ON DUPLICATE KEY updates for MariaDB
- refactor the IGDB rename script and lookup tests to consume generic mapping rows instead of sqlite3.Row objects

## Testing
- `pytest tests/test_lookup_tables.py -vv` *(fails: sqlite database is locked during schema migration)*

------
https://chatgpt.com/codex/tasks/task_e_68e12b21bbc0833398d356b192db2296