### PR TITLE
Refine lookup helpers for SQLAlchemy connections

### DIFF
--- a/tests/app_helpers.py
+++ b/tests/app_helpers.py
@@ -85,7 +85,7 @@ def load_app(tmp_path: Path) -> object:
         )
 
     if hasattr(module, "_ensure_lookup_join_tables") and hasattr(module, "db"):
-        with module.db_lock, module.db.connection() as conn:
+        with module.db_lock, module.db.sa_connection() as conn:
             module._ensure_lookup_join_tables(conn)
 
     if (
@@ -101,7 +101,7 @@ def load_app(tmp_path: Path) -> object:
         and hasattr(module, "_recreate_lookup_join_tables")
         and hasattr(module, "db")
     ):
-        with module.db_lock, module.db.connection() as conn:
+        with module.db_lock, module.db.sa_connection() as conn:
             module._recreate_lookup_join_tables(conn)
 
     if (


### PR DESCRIPTION
## Summary
- allow lookup helpers in app.py to operate on SQLAlchemy `Engine` objects by routing through a shared connection helper
- adjust join-table DDL to remain MariaDB compliant while retaining identifier quoting
- update the test loader to exercise join-table creation through SQLAlchemy connections

## Testing
- pytest tests/app_helpers.py

------
https://chatgpt.com/codex/tasks/task_e_68e1b540cba0833399d699994e784360