### PR TITLE
Add MariaDB-compatible tests and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,70 @@
+name: CI
+
+on:
+  push:
+    branches: ["main", "master"]
+  pull_request:
+
+jobs:
+  tests-sqlite:
+    name: Tests (SQLite)
+    runs-on: ubuntu-latest
+    env:
+      DB_LEGACY_SQLITE: "1"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest
+      - name: Run pytest
+        run: pytest
+  tests-mariadb:
+    name: Tests (MariaDB)
+    runs-on: ubuntu-latest
+    services:
+      mariadb:
+        image: mariadb:10.11
+        env:
+          MARIADB_ROOT_PASSWORD: root
+          MARIADB_DATABASE: tt_game_liste
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd "mysqladmin ping -h 127.0.0.1 -uroot -proot"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DB_LEGACY_SQLITE: "0"
+      DB_HOST: 127.0.0.1
+      DB_PORT: "3306"
+      DB_NAME: tt_game_liste
+      DB_USER: root
+      DB_PASSWORD: root
+      DB_CONNECT_TIMEOUT: "10"
+      DB_READ_TIMEOUT: "30"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest
+      - name: Wait for MariaDB
+        run: |
+          for i in {1..30}; do
+            if mysqladmin ping -h 127.0.0.1 -uroot -proot --silent; then
+              break
+            fi
+            sleep 2
+          done
+      - name: Run pytest
+        run: pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,14 @@
+"""Pytest fixtures shared across the test suite."""
+
 import os
 
-import pytest
-
-
 os.environ.setdefault('DB_LEGACY_SQLITE', '1')
+
+import pytest
+from sqlalchemy import inspect, text
+
+from config import DB_DSN, DB_LEGACY_SQLITE
+from db import utils as db_utils
 
 
 @pytest.fixture(autouse=True)
@@ -13,3 +18,31 @@ def enable_db_migrations(monkeypatch):
     monkeypatch.setenv('RUN_DB_MIGRATIONS', '1')
     yield
     monkeypatch.delenv('RUN_DB_MIGRATIONS', raising=False)
+
+
+@pytest.fixture(autouse=True)
+def reset_database_state():
+    """Reset cached handles and clean MariaDB schemas between tests."""
+
+    db_utils.set_fallback_connection(None)
+    db_utils.clear_processed_games_columns_cache()
+
+    if not DB_LEGACY_SQLITE:
+        engine_wrapper = db_utils.build_engine_from_dsn(DB_DSN)
+        engine = engine_wrapper.engine
+        with engine.connect() as conn:
+            with conn.begin():
+                inspector = inspect(conn)
+                tables = inspector.get_table_names()
+                if tables:
+                    conn.execute(text('SET FOREIGN_KEY_CHECKS = 0'))
+                    preparer = conn.dialect.identifier_preparer
+                    for table in tables:
+                        conn.execute(text(f"DROP TABLE IF EXISTS {preparer.quote(table)}"))
+                    conn.execute(text('SET FOREIGN_KEY_CHECKS = 1'))
+        engine_wrapper.dispose()
+
+    yield
+
+    db_utils.set_fallback_connection(None)
+    db_utils.clear_processed_games_columns_cache()

--- a/tests/test_db_creation.py
+++ b/tests/test_db_creation.py
@@ -1,6 +1,23 @@
-from tests.app_helpers import load_app
+"""Smoke tests covering processed-games database initialization."""
+
+from db import utils as db_utils
+
+from tests.app_helpers import load_app, using_legacy_sqlite
+
 
 def test_db_created_without_migration(tmp_path):
+    """The application should create the processed games schema on startup."""
+
     assert not (tmp_path / "processed_games.xlsx").exists()
-    load_app(tmp_path)
-    assert (tmp_path / "processed_games.db").exists()
+
+    app = load_app(tmp_path)
+
+    with app.db_lock:
+        db_utils.clear_processed_games_columns_cache()
+        columns = db_utils.get_processed_games_columns(handle=app.db)
+
+    assert 'ID' in columns
+    assert 'Source Index' in columns
+
+    if using_legacy_sqlite():
+        assert (tmp_path / "processed_games.db").exists()


### PR DESCRIPTION
## Summary
- ensure MariaDB sessions inherit ANSI_QUOTES and timeout tuning when connections are created.【F:db/utils.py†L316-L370】
- add shared helpers/fixtures so tests configure the active backend and clean MariaDB schemas during runs.【F:tests/app_helpers.py†L1-L158】【F:tests/conftest.py†L1-L48】
- refresh database-oriented tests to use the new helpers and backend-agnostic schema introspection.【F:tests/test_db_creation.py†L1-L23】【F:tests/test_lookup_tables.py†L1-L176】【F:tests/test_navigator_state.py†L1-L222】
- create a GitHub Actions workflow that exercises the suite against SQLite and MariaDB backends.【F:.github/workflows/ci.yml†L1-L70】

## Testing
- pytest tests/test_db_creation.py -q【7b7c91†L1-L9】
- pytest tests/test_lookup_tables.py -q【b8d59f†L1-L9】
- pytest tests/test_navigator_state.py::test_out_of_order_ids_are_normalized -q【167ab4†L1-L9】

------
https://chatgpt.com/codex/tasks/task_e_68e473272e0c8333bc5007c191669308